### PR TITLE
Remove highs slack tests

### DIFF
--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1778,32 +1778,6 @@ class TestLinprogHiGHSSimplex(LinprogHiGHSTests):
     options = {}
 
 
-    def test_slack_lpgen_2d_trivial(self):
-        for m in range(1, 10):
-            for n in range(1, 10):
-                A_ub, b_ub, c = lpgen_2d(m, n)
-                res0 = linprog(c, A_ub, b_ub, method='revised simplex')
-                res1 = linprog(c, A_ub, b_ub, method='highs-simplex')
-                assert_allclose(res0.slack, res1.slack, atol=1e-10)
-
-
-    def test_magic_square_slack(self):
-        for n in range(1, 10):
-            A, b, c, _numbers = magic_square(n)
-            res0 = linprog(c, A_ub, b_ub, method='revised simplex')
-            res1 = linprog(c, A_ub, b_ub, method='highs-simplex')
-            assert_allclose(res0.slack, res1.slack, atol=1e-10)
-
-
-    def test_nontrivial_problem_slack(self):
-
-        c, A_ub, b_ub, A_eq, b_eq, x_star, f_star = nontrivial_problem()
-        res0 = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, method='revised simplex')
-        res1 = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, method='highs-simplex')
-        print(res0.slack, res1.slack)
-        assert_allclose(res0.slack, res1.slack[:len(res0.slack)], atol=1e-10)
-
-
 #######################################
 # HiGHS-Simplex Option-Specific Tests #
 #######################################


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

HiGHS scipy integration https://github.com/scipy/scipy/pull/11759

#### What does this implement/fix?
<!--Please explain your changes.-->

- Fixes https://github.com/mckib2/HiGHS/issues/33
- Removes exploratory slack tests

#### Additional information
<!--Any additional information you think is important.-->

I had added a few tests to try out some slack comparison and forgot to remove.  These caused the PEP8 issues.  Removing them should fix current Travis CI build errors.