### PR TITLE
TST: add SAS expected values with 15 decimals for Somers' D

### DIFF
--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -206,12 +206,12 @@ class TestSomersD(object):
         res4 = stats.somersd(s4)
 
         # Cross-check with result from SAS FREQ:
-        assert_allclose(res.statistic, -0.116981132075470)
+        assert_allclose(res.statistic, -0.116981132075470, atol=1e-15)
         assert_allclose(res.statistic, res2.statistic)
         assert_allclose(res.statistic, res3.statistic)
         assert_allclose(res.statistic, res4.statistic)
 
-        assert_allclose(res.pvalue, 0.156376448188150)
+        assert_allclose(res.pvalue, 0.156376448188150, atol=1e-15)
         assert_allclose(res.pvalue, res2.pvalue)
         assert_allclose(res.pvalue, res3.pvalue)
         assert_allclose(res.pvalue, res4.pvalue)

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -23,8 +23,8 @@ class TestSomersD(object):
         # Cross-check with result from SAS FREQ:
         expected = (0.000000000000000, 1.000000000000000)
         res = stats.somersd(x, y)
-        assert_allclose(res.statistic, expected[0])
-        assert_allclose(res.pvalue, expected[1])
+        assert_allclose(res.statistic, expected[0], atol=1e-15)
+        assert_allclose(res.pvalue, expected[1], atol=1e-15)
 
         # case without ties, con-dis equal zero
         x = [0, 5, 2, 1, 3, 6, 4, 7, 8]
@@ -76,22 +76,23 @@ class TestSomersD(object):
         # swap a couple values and a couple more
         x = np.arange(10)
         y = np.array([9, 7, 8, 6, 5, 3, 4, 2, 1, 0])
+        # Cross-check with result from SAS FREQ:
         expected = (-0.9111111111111111, 0.000000000000000)
         res = stats.somersd(x, y)
         assert_allclose(res.statistic, expected[0], atol=1e-15)
         assert_allclose(res.pvalue, expected[1], atol=1e-15)
 
         # with some ties
-        # Cross-check with result from SAS FREQ:
         x1 = [12, 2, 1, 12, 2]
         x2 = [1, 4, 7, 1, 0]
+        # Cross-check with result from SAS FREQ:
         expected = (-0.500000000000000, 0.304901788178780)
         res = stats.somersd(x1, x2)
         assert_allclose(res.statistic, expected[0], atol=1e-15)
         assert_allclose(res.pvalue, expected[1], atol=1e-15)
 
         # with only ties in one or both inputs
-        # SAS will not produce an output for this:
+        # SAS will not produce an output for these:
         '''
         NOTE: No statistics are computed for x * y because x has fewer than 2 nonmissing levels.
         WARNING: No OUTPUT data set is produced for this table because a row or column variable has fewer
@@ -101,29 +102,14 @@ class TestSomersD(object):
         assert_allclose(res.statistic, np.nan)
         assert_allclose(res.pvalue, np.nan)
 
-        '''
-        NOTE: No statistics are computed for x * y because y has fewer than 2 nonmissing levels.
-        WARNING: No OUTPUT data set is produced for this table because a row or column variable has fewer
-            than 2 nonmissing levels and no statistics are computed.
-        '''
         res = stats.somersd([2, 0, 2], [2, 2, 2])
         assert_allclose(res.statistic, np.nan)
         assert_allclose(res.pvalue, np.nan)
 
-        '''
-        NOTE: No statistics are computed for x * y because x has fewer than 2 nonmissing levels.
-        WARNING: No OUTPUT data set is produced for this table because a row or column variable has fewer
-            than 2 nonmissing levels and no statistics are computed.
-        '''
         res = stats.somersd([2, 2, 2], [2, 0, 2])
         assert_allclose(res.statistic, np.nan)
         assert_allclose(res.pvalue, np.nan)
 
-        '''
-        NOTE: No statistics are computed for x * y because x has fewer than 2 nonmissing levels.
-        WARNING: No OUTPUT data set is produced for this table because a row or column variable has fewer
-            than 2 nonmissing levels and no statistics are computed.
-        '''
         res = stats.somersd([0], [0])
         assert_allclose(res.statistic, np.nan)
         assert_allclose(res.pvalue, np.nan)

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -48,7 +48,8 @@ class TestSomersD(object):
         x = np.arange(10)
         y = np.arange(10)
         # Cross-check with result from SAS FREQ:
-        expected = (1.0, 0)
+        # SAS p value is not provided. 
+        expected = (1.000000000000000, 0) 
         res = stats.somersd(x, y)
         assert_allclose(res.statistic, expected[0], atol=1e-4)
         assert_allclose(res.pvalue, expected[1], atol=1e-4)
@@ -66,7 +67,8 @@ class TestSomersD(object):
         x = np.arange(10)
         y = np.arange(10)[::-1]
         # Cross-check with result from SAS FREQ:
-        expected = (-1.000000000000000, "NAN?")
+        # SAS p value is not provided. 
+        expected = (-1.000000000000000, 0)
         res = stats.somersd(x, y)
         assert_allclose(res.statistic, expected[0], atol=1e-4)
         assert_allclose(res.pvalue, expected[1], atol=1e-4)

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -21,7 +21,7 @@ class TestSomersD(object):
         x = [5, 2, 1, 3, 6, 4, 7, 8]
         y = [5, 2, 6, 3, 1, 8, 7, 4]
         # Cross-check with result from SAS FREQ:
-        expected = (0.0, 1.0)
+        expected = (0.000000000000000, 1.000000000000000)
         res = stats.somersd(x, y)
         assert_allclose(res.statistic, expected[0])
         assert_allclose(res.pvalue, expected[1])
@@ -30,7 +30,7 @@ class TestSomersD(object):
         x = [0, 5, 2, 1, 3, 6, 4, 7, 8]
         y = [5, 2, 0, 6, 3, 1, 8, 7, 4]
         # Cross-check with result from SAS FREQ:
-        expected = (0.0, 1.0)
+        expected = (0.000000000000000, 1.000000000000000)
         res = stats.somersd(x, y)
         assert_allclose(res.statistic, expected[0])
         assert_allclose(res.pvalue, expected[1])
@@ -39,7 +39,7 @@ class TestSomersD(object):
         x = [5, 2, 1, 3, 6, 4, 7]
         y = [5, 2, 6, 3, 1, 7, 4]
         # Cross-check with result from SAS FREQ:
-        expected = (-0.1429, 0.6303)
+        expected = (-0.142857142857140, 0.630326953157670)
         res = stats.somersd(x, y)
         assert_allclose(res.statistic, expected[0], atol=1e-4)
         assert_allclose(res.pvalue, expected[1], atol=1e-4)
@@ -57,7 +57,7 @@ class TestSomersD(object):
         x = np.arange(10)
         y = np.array([0, 2, 1, 3, 4, 6, 5, 7, 8, 9])
         # Cross-check with result from SAS FREQ:
-        expected = (0.9111, 0)
+        expected = (0.911111111111110, 0.000000000000000)
         res = stats.somersd(x, y)
         assert_allclose(res.statistic, expected[0], atol=1e-4)
         assert_allclose(res.pvalue, expected[1], atol=1e-4)
@@ -66,7 +66,7 @@ class TestSomersD(object):
         x = np.arange(10)
         y = np.arange(10)[::-1]
         # Cross-check with result from SAS FREQ:
-        expected = (-1.0, 5.511463844797e-07)
+        expected = (-1.000000000000000, "NAN?")
         res = stats.somersd(x, y)
         assert_allclose(res.statistic, expected[0], atol=1e-4)
         assert_allclose(res.pvalue, expected[1], atol=1e-4)
@@ -83,24 +83,45 @@ class TestSomersD(object):
         # Cross-check with result from SAS FREQ:
         x1 = [12, 2, 1, 12, 2]
         x2 = [1, 4, 7, 1, 0]
-        expected = (-0.5, 0.3049017881787882)
+        expected = (-0.500000000000000, 0.304901788178780)
         res = stats.somersd(x1, x2)
         assert_allclose(res.statistic, expected[0])
         assert_allclose(res.pvalue, expected[1])
 
         # with only ties in one or both inputs
+        # SAS will not produce an output for this:
+        '''
+        NOTE: No statistics are computed for x * y because x has fewer than 2 nonmissing levels.
+        WARNING: No OUTPUT data set is produced for this table because a row or column variable has fewer
+            than 2 nonmissing levels and no statistics are computed.
+        '''
         res = stats.somersd([2, 2, 2], [2, 2, 2])
         assert_allclose(res.statistic, np.nan)
         assert_allclose(res.pvalue, np.nan)
 
+        '''
+        NOTE: No statistics are computed for x * y because y has fewer than 2 nonmissing levels.
+        WARNING: No OUTPUT data set is produced for this table because a row or column variable has fewer
+            than 2 nonmissing levels and no statistics are computed.
+        '''
         res = stats.somersd([2, 0, 2], [2, 2, 2])
         assert_allclose(res.statistic, np.nan)
         assert_allclose(res.pvalue, np.nan)
 
+        '''
+        NOTE: No statistics are computed for x * y because x has fewer than 2 nonmissing levels.
+        WARNING: No OUTPUT data set is produced for this table because a row or column variable has fewer
+            than 2 nonmissing levels and no statistics are computed.
+        '''
         res = stats.somersd([2, 2, 2], [2, 0, 2])
         assert_allclose(res.statistic, np.nan)
         assert_allclose(res.pvalue, np.nan)
 
+        '''
+        NOTE: No statistics are computed for x * y because x has fewer than 2 nonmissing levels.
+        WARNING: No OUTPUT data set is produced for this table because a row or column variable has fewer
+            than 2 nonmissing levels and no statistics are computed.
+        '''
         res = stats.somersd([0], [0])
         assert_allclose(res.statistic, np.nan)
         assert_allclose(res.pvalue, np.nan)
@@ -128,9 +149,9 @@ class TestSomersD(object):
         y = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2,
              2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
         # Cross-check with result from SAS FREQ:
-        d_cr = 0.2727
-        d_rc = 0.3429
-        p = 0.0929  # same p-value for either direction
+        d_cr = 0.272727272727270
+        d_rc = 0.342857142857140
+        p = 0.092891940883700  # same p-value for either direction
         res = stats.somersd(x, y)
         assert_allclose(res.statistic, d_cr, atol=1e-4)
         assert_allclose(res.pvalue, p, atol=1e-4)
@@ -183,12 +204,12 @@ class TestSomersD(object):
         res4 = stats.somersd(s4)
 
         # Cross-check with result from SAS FREQ:
-        assert_allclose(res.statistic, -0.1169811320754717)
+        assert_allclose(res.statistic, -0.116981132075470)
         assert_allclose(res.statistic, res2.statistic)
         assert_allclose(res.statistic, res3.statistic)
         assert_allclose(res.statistic, res4.statistic)
 
-        assert_allclose(res.pvalue, 0.15637644818814952)
+        assert_allclose(res.pvalue, 0.156376448188150)
         assert_allclose(res.pvalue, res2.pvalue)
         assert_allclose(res.pvalue, res3.pvalue)
         assert_allclose(res.pvalue, res4.pvalue)

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -32,8 +32,8 @@ class TestSomersD(object):
         # Cross-check with result from SAS FREQ:
         expected = (0.000000000000000, 1.000000000000000)
         res = stats.somersd(x, y)
-        assert_allclose(res.statistic, expected[0])
-        assert_allclose(res.pvalue, expected[1])
+        assert_allclose(res.statistic, expected[0], atol=1e-15)
+        assert_allclose(res.pvalue, expected[1], atol=1e-15)
 
         # case without ties, con-dis close to zero
         x = [5, 2, 1, 3, 6, 4, 7]
@@ -41,8 +41,8 @@ class TestSomersD(object):
         # Cross-check with result from SAS FREQ:
         expected = (-0.142857142857140, 0.630326953157670)
         res = stats.somersd(x, y)
-        assert_allclose(res.statistic, expected[0], atol=1e-4)
-        assert_allclose(res.pvalue, expected[1], atol=1e-4)
+        assert_allclose(res.statistic, expected[0], atol=1e-15)
+        assert_allclose(res.pvalue, expected[1], atol=1e-15)
 
         # simple case without ties
         x = np.arange(10)
@@ -51,8 +51,8 @@ class TestSomersD(object):
         # SAS p value is not provided. 
         expected = (1.000000000000000, 0) 
         res = stats.somersd(x, y)
-        assert_allclose(res.statistic, expected[0], atol=1e-4)
-        assert_allclose(res.pvalue, expected[1], atol=1e-4)
+        assert_allclose(res.statistic, expected[0], atol=1e-15)
+        assert_allclose(res.pvalue, expected[1], atol=1e-15)
 
         # swap a couple values and a couple more
         x = np.arange(10)
@@ -60,8 +60,8 @@ class TestSomersD(object):
         # Cross-check with result from SAS FREQ:
         expected = (0.911111111111110, 0.000000000000000)
         res = stats.somersd(x, y)
-        assert_allclose(res.statistic, expected[0], atol=1e-4)
-        assert_allclose(res.pvalue, expected[1], atol=1e-4)
+        assert_allclose(res.statistic, expected[0], atol=1e-15)
+        assert_allclose(res.pvalue, expected[1], atol=1e-15)
 
         # same in opposite direction
         x = np.arange(10)
@@ -70,16 +70,16 @@ class TestSomersD(object):
         # SAS p value is not provided. 
         expected = (-1.000000000000000, 0)
         res = stats.somersd(x, y)
-        assert_allclose(res.statistic, expected[0], atol=1e-4)
-        assert_allclose(res.pvalue, expected[1], atol=1e-4)
+        assert_allclose(res.statistic, expected[0], atol=1e-15)
+        assert_allclose(res.pvalue, expected[1], atol=1e-15)
 
         # swap a couple values and a couple more
         x = np.arange(10)
         y = np.array([9, 7, 8, 6, 5, 3, 4, 2, 1, 0])
-        expected = (-0.9111111111111111, 2.976190476190e-05)
+        expected = (-0.9111111111111111, 0.000000000000000)
         res = stats.somersd(x, y)
-        assert_allclose(res.statistic, expected[0], atol=1e-4)
-        assert_allclose(res.pvalue, expected[1], atol=1e-4)
+        assert_allclose(res.statistic, expected[0], atol=1e-15)
+        assert_allclose(res.pvalue, expected[1], atol=1e-15)
 
         # with some ties
         # Cross-check with result from SAS FREQ:
@@ -87,8 +87,8 @@ class TestSomersD(object):
         x2 = [1, 4, 7, 1, 0]
         expected = (-0.500000000000000, 0.304901788178780)
         res = stats.somersd(x1, x2)
-        assert_allclose(res.statistic, expected[0])
-        assert_allclose(res.pvalue, expected[1])
+        assert_allclose(res.statistic, expected[0], atol=1e-15)
+        assert_allclose(res.pvalue, expected[1], atol=1e-15)
 
         # with only ties in one or both inputs
         # SAS will not produce an output for this:
@@ -155,12 +155,12 @@ class TestSomersD(object):
         d_rc = 0.342857142857140
         p = 0.092891940883700  # same p-value for either direction
         res = stats.somersd(x, y)
-        assert_allclose(res.statistic, d_cr, atol=1e-4)
+        assert_allclose(res.statistic, d_cr, atol=1e-15)
         assert_allclose(res.pvalue, p, atol=1e-4)
         assert_equal(res.table.shape, (3, 2))
         res = stats.somersd(y, x)
-        assert_allclose(res.statistic, d_rc, atol=1e-4)
-        assert_allclose(res.pvalue, p, atol=1e-4)
+        assert_allclose(res.statistic, d_rc, atol=1e-15)
+        assert_allclose(res.pvalue, p, atol=1e-15)
         assert_equal(res.table.shape, (2, 3))
 
     def test_somers_original(self):


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
for gh-12653, [comment](https://github.com/scipy/scipy/pull/12653#issuecomment-667886352)
#### What does this implement/fix?
<!--Please explain your changes.-->
Add more precision to test examples for somers' d, up to 15 decimals



SAS testing was done with this script:
```
data example1;
input x y;
cards;
**data here**
;
proc freq;
tables x*y;
test SMDRC SMDCR;
	format _SMDCR_ P2_SMDCR _SMDRC_ P2_SMDRC comma20.15;
OUTPUT SMDCR SMDRC;
proc print;
run;
```

#### Additional information
<!--Any additional information you think is important.-->

Interestingly, for some of these where the p value is 0, SAS refused to calculate a p value. No error message, just this: 
(`P2_SMDCR` is the two tailed p value, in right bottom corner )

![Screen Shot 2020-08-03 at 7 21 33 PM](https://user-images.githubusercontent.com/44255917/89246064-271e7a00-d5bf-11ea-894c-a2a749f5df06.png)

For some, an error was displayed in the console, and nothing at all about somers d was shown. I have copied the error message for each errored test directly above it in a comment. The messages are all the same except for mentioning x or y as the problem input. 
