### PR TITLE
Try to use numpy's Mersenne Twister implementation

### DIFF
--- a/scipy/stats/biasedurn.pyx
+++ b/scipy/stats/biasedurn.pyx
@@ -30,7 +30,7 @@ cdef class _PyStochasticLib3:
 
     def __cinit__(self, int seed):
         self.c_sl3 = StochasticLib3(seed)
-                
+
     def SetAccuracy(self, double accur):
         return self.c_sl3.SetAccuracy(accur)
 

--- a/scipy/stats/biasedurn/fnchyppr.cpp
+++ b/scipy/stats/biasedurn/fnchyppr.cpp
@@ -9,20 +9,21 @@
 * Calculation of univariate and multivariate Fisher's noncentral hypergeometric
 * probability distribution.
 *
-* This file contains source code for the class CFishersNCHypergeometric 
+* This file contains source code for the class CFishersNCHypergeometric
 * and CMultiFishersNCHypergeometric defined in stocc.h.
 *
 * Documentation:
 * ==============
 * The file stocc.h contains class definitions.
-* The file ran-instructions.pdf contains further documentation and 
+* The file ran-instructions.pdf contains further documentation and
 * instructions.
 *
-* Copyright 2002-2014 by Agner Fog. 
+* Copyright 2002-2014 by Agner Fog.
 * GNU General Public License http://www.gnu.org/licenses/gpl.html
 *****************************************************************************/
 
 #include <string.h>                    // memcpy function
+#include <stdexcept>
 #include "stocc.h"                     // class definition
 
 
@@ -30,9 +31,15 @@
 Methods for class CFishersNCHypergeometric
 ***********************************************************************/
 
-void FatalError(const char * ErrorText) {
-  throw *ErrorText;
+//void FatalError(const char * ErrorText) {
+//  throw *ErrorText;
+//}
+
+// Caught as ValueError by Python
+void FatalError(const char* msg) {
+  throw std::domain_error(msg);
 }
+
 
 CFishersNCHypergeometric::CFishersNCHypergeometric(){}
 
@@ -61,22 +68,22 @@ int32_t CFishersNCHypergeometric::mode(void) {
    // Find mode (exact)
    // Uses the method of Liao and Rosen, The American Statistician, vol 55,
    // no 4, 2001, p. 366-369.
-   // Note that there is an error in Liao and Rosen's formula. 
-   // Replace sgn(b) with -1 in Liao and Rosen's formula. 
+   // Note that there is an error in Liao and Rosen's formula.
+   // Replace sgn(b) with -1 in Liao and Rosen's formula.
 
    double A, B, C, D;                  // coefficients for quadratic equation
    double x;                           // mode
    int32_t L = m + n - N;
    int32_t m1 = m+1, n1 = n+1;
 
-   if (odds == 1.) { 
+   if (odds == 1.) {
       // simple hypergeometric
       x = (m + 1.) * (n + 1.) / (N + 2.);
    }
    else {
       // calculate analogously to Cornfield mean
       A = 1. - odds;
-      B = (m1+n1)*odds - L; 
+      B = (m1+n1)*odds - L;
       C = -(double)m1*n1*odds;
       D = B*B -4*A*C;
       D = D > 0. ? sqrt(D) : 0.;
@@ -96,7 +103,7 @@ double CFishersNCHypergeometric::mean(void) {
       return double(m)*n/N;
    }
    // calculate Cornfield mean
-   a = (m+n)*odds + (N-m-n); 
+   a = (m+n)*odds + (N-m-n);
    b = a*a - 4.*odds*(odds-1.)*m*n;
    b = b > 0. ? sqrt(b) : 0.;
    mean = (a-b)/(2.*(odds-1.));
@@ -105,7 +112,7 @@ double CFishersNCHypergeometric::mean(void) {
 
 
 double CFishersNCHypergeometric::variance(void) {
-   // find approximate variance (poor approximation)    
+   // find approximate variance (poor approximation)
    double my = mean(); // approximate mean
    // find approximate variance from Fisher's noncentral hypergeometric approximation
    double r1 = my * (m-my); double r2 = (n-my)*(my+N-n-m);
@@ -165,7 +172,7 @@ double CFishersNCHypergeometric::probability(int32_t x) {
    }
 
    if (!rsum) {
-      // first time. calculate rsum = reciprocal of sum of proportional 
+      // first time. calculate rsum = reciprocal of sum of proportional
       // function over all probable x values
       int32_t x1, x2;                    // x loop
       double y;                        // value of proportional function
@@ -175,7 +182,7 @@ double CFishersNCHypergeometric::probability(int32_t x) {
       scale = 0.; scale = lng(x1);     // calculate scale to avoid overflow
       rsum = 1.;                       // = exp(lng(x1)) with this scale
       for (x1--; x1 >= xmin; x1--) {
-         rsum += y = exp(lng(x1));     // sum from x1 and down 
+         rsum += y = exp(lng(x1));     // sum from x1 and down
          if (y < accur) break;         // until value becomes negligible
       }
       for (; x2 <= xmax; x2++) {       // sum from x2 and up
@@ -245,13 +252,13 @@ double CFishersNCHypergeometric::MakeTable(double * table, int32_t MaxLength, in
    // is the sum, s, of all the values in the table. The normalized
    // probabilities are obtained by multiplying all values in the table by
    // 1/s.
-   // The tails are cut off where the values are < cutoff, so that 
+   // The tails are cut off where the values are < cutoff, so that
    // *xfirst may be > xmin and *xlast may be < xmax.
    // The value of cutoff will be 0.01 * accuracy if not specified.
-   // The first and last x value represented in the table are returned in 
-   // *xfirst and *xlast. The resulting probability values are returned in the 
+   // The first and last x value represented in the table are returned in
+   // *xfirst and *xlast. The resulting probability values are returned in the
    // first (*xlast - *xfirst + 1) positions of table. If this would require
-   // more than MaxLength values then the table is filled with as many 
+   // more than MaxLength values then the table is filled with as many
    // correct values as possible.
    //
    // The function will return the desired length of table when MaxLength = 0.
@@ -396,7 +403,7 @@ CMultiFishersNCHypergeometric::CMultiFishersNCHypergeometric(int32_t n_, int32_t
    int i;
    // copy parameters
    n = n_;  m = m_;  odds = odds_;  colors = colors_;  accuracy = accuracy_;
-   // check if parameters are valid 
+   // check if parameters are valid
    // (Note: there is a more thorough test for validity in the BiasedUrn package)
    for (N = N1 = 0, i = 0; i < colors; i++) {
       if (m[i] < 0 || odds[i] < 0) FatalError("Parameter negative in constructor for CMultiFishersNCHypergeometric");
@@ -492,7 +499,7 @@ double CMultiFishersNCHypergeometric::probability(int32_t * x) {
    // Note: The first-time call takes very long time because it requires
    // a calculation of all possible x combinations with probability >
    // accuracy, which may be extreme.
-   // The calculation uses logarithms to avoid overflow. 
+   // The calculation uses logarithms to avoid overflow.
    // (Recursive calculation may be faster, but this has not been implemented)
    // Note: The version in BiasedUrn package deals with unused colors
    int32_t xsum;  int i, em;
@@ -515,7 +522,7 @@ double CMultiFishersNCHypergeometric::probability(int32_t * x) {
 
 
 double CMultiFishersNCHypergeometric::moments(double * mean, double * variance, int32_t * combinations) {
-   // calculates mean and variance of the Fisher's noncentral hypergeometric 
+   // calculates mean and variance of the Fisher's noncentral hypergeometric
    // distribution by calculating all combinations of x-values with
    // probability > accuracy.
    // Return value = 1.
@@ -541,7 +548,7 @@ double CMultiFishersNCHypergeometric::moments(double * mean, double * variance, 
 void CMultiFishersNCHypergeometric::SumOfAll() {
    // this function does the very time consuming job of calculating the sum
    // of the proportional function g(x) over all possible combinations of
-   // the x[i] values with probability > accuracy. These combinations are 
+   // the x[i] values with probability > accuracy. These combinations are
    // generated by the recursive function loop().
    // The mean and variance are generated as by-products.
 
@@ -621,7 +628,7 @@ double CMultiFishersNCHypergeometric::loop(int32_t n, int c) {
    else {
       // last color
       xi[c] = n;
-      // sums and squaresums    
+      // sums and squaresums
       s1 = exp(lng(xi));               // proportional function g(x)
       for (i = 0; i < colors; i++) {   // update sums
          sx[i]  += s1 * xi[i];

--- a/scipy/stats/setup.py
+++ b/scipy/stats/setup.py
@@ -1,6 +1,7 @@
 from os.path import join
+import pathlib
+import numpy as np
 
-      
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration('stats', parent_package, top_path)
@@ -29,15 +30,24 @@ def configuration(parent_package='',top_path=None):
     )
 
     # Build BiasedUrn
+    # Find MT19937 shared lib packaged with numpy
+    mt_lib = list((pathlib.Path(np.get_include()).parent.parent / 'random').glob('_mt19937*'))[0]
     config.add_data_files('BiasedUrn.pxd')
     config.add_extension(
-        'biasedurn', sources=['biasedurn.cxx',
-                              'biasedurn/fnchyppr.cpp',
-                              'biasedurn/wnchyppr.cpp',
-                              'biasedurn/stoc1.cpp',
-                              'biasedurn/stoc3.cpp',
-                              'biasedurn/mersenne.cpp'])
-    
+        'biasedurn',
+        sources=['biasedurn.cxx',
+                 'biasedurn/fnchyppr.cpp',
+                 'biasedurn/wnchyppr.cpp',
+                 'biasedurn/stoc1.cpp',
+                 'biasedurn/stoc3.cpp',
+                 #'biasedurn/mersenne.cpp',
+        ],
+        library_dirs=[str(mt_lib.parent)],
+        libraries=[':' + mt_lib.name], # TODO: hacky, not sure if cross-platform
+                                       # produces -l:[path-to-shared-lib].so on Ubuntu 18
+        runtime_library_dirs=[str(mt_lib.parent)],
+    )
+
     return config
 
 


### PR DESCRIPTION
- tries to use as much MT19937 machinery from numpy as possible; some numpy functions are not extern so had to be reproduced in `randomc.h`
- steals the shared library from numpy -- I doubt it is cross platform as currently written in `setup.py`

The idea I had was to just try using what's accessible in numpy to see if I could get something to work.  I'm not expecting that this is the final solution.  Since random functions from numpy must be used, I wanted to see what is accessible from C++.  There is some that you can get at in a hacky way, but I'm interested to learn more.

It looks like there [used to be](https://github.com/scipy/scipy/commit/9af691f49c087ab312f2a9c045c5be9bcf36e122) a Mersenne Twister implementation in scipy, but was removed.  It looks like there are many [implementations](https://en.wikipedia.org/wiki/Mersenne_Twister#Adoption_in_software_systems) available if you think it's worth using one of those over numpy's.  It would be much easier to use the numpy implementation if I could change some headers to declare functions as extern, maybe that's something we can look into.

Some numbers are produced by the test script you provided in the original PR.  I don't know if they are the correct ones, you'll have to let me know.