### PR TITLE
FIX: add compatibility headers for numpy random c api.

### DIFF
--- a/scipy/_build_utils/npy_1_18_compat/__init__.py
+++ b/scipy/_build_utils/npy_1_18_compat/__init__.py
@@ -1,0 +1,4 @@
+import pathlib
+
+def get_include() -> str:
+    return str(pathlib.Path(__file__).parent)

--- a/scipy/_build_utils/npy_1_18_compat/numpy/random/bitgen.h
+++ b/scipy/_build_utils/npy_1_18_compat/numpy/random/bitgen.h
@@ -1,0 +1,22 @@
+/* Vendor numpy/random/bitgen.h for numpy<=1.17 */
+
+#ifndef _RANDOM_BITGEN_H
+#define _RANDOM_BITGEN_H
+
+#pragma once
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Must match the declaration in numpy/random/<any>.pxd */
+
+typedef struct bitgen {
+  void *state;
+  uint64_t (*next_uint64)(void *st);
+  uint32_t (*next_uint32)(void *st);
+  double (*next_double)(void *st);
+  uint64_t (*next_raw)(void *st);
+} bitgen_t;
+
+
+#endif

--- a/scipy/stats/setup.py
+++ b/scipy/stats/setup.py
@@ -39,6 +39,12 @@ def configuration(parent_package='',top_path=None):
 
     # add BiasedUrn module
     config.add_data_files(['random.pxd', 'biasedurn.pxd'])
+    npy_major_version = int(np.__version__.split('.')[1])
+    if npy_major_version >= 18:
+        inc_dirs = [np.get_include()]
+    else:
+        from scipy._build_utils.npy_1_18_compat import get_include
+        inc_dirs = [get_include()]
     ext = config.add_extension(
         'biasedurn',
         sources=[
@@ -48,7 +54,7 @@ def configuration(parent_package='',top_path=None):
             'biasedurn/wnchyppr.cpp',
             'biasedurn/stoc1.cpp',
             'biasedurn/stoc3.cpp'],
-        include_dirs=[np.get_include()],
+        include_dirs=inc_dirs,
         define_macros=[('R_BUILD', None)],
         language='c++',
         extra_compile_args=['-Wno-narrowing'] if system() == 'Darwin' else [],


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

@mdhaber This doesn't feel like the prettiest solution, but it might help us and gh-11954 if this PR gets in before them.

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

- adds missing c api headers for `numpy.random` to get `bitgen_t` for environments with numpy<1.18

#### Additional information
<!--Any additional information you think is important.-->