### PR TITLE
BUG: stats: fix handling of size in _nch_gen._rvs

### DIFF
--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -256,3 +256,13 @@ class TestNCH():
             # the naive implementation is very wrong in these cases
             assert pmf(x, N, m1, n, w).sum() < .5
             assert_allclose(wnch.pmf(x, N, m1, n, w).sum(), 1)
+
+    @pytest.mark.parametrize('dist_name', ['fnch', 'wnch'])
+    def test_rvs_shape(self, dist_name):
+        # Check that when given a size with more dimensions than the
+        # dimensions of the broadcast parameters, rvs returns an array
+        # with the correct shape.
+        dists = {'fnch': fnch, 'wnch': wnch}
+        dist = dists[dist_name]
+        x = dist.rvs(50, 30, [[10], [20]], [0.5, 1.0, 2.0], size=(5, 1, 2, 3))
+        assert x.shape == (5, 1, 2, 3)


### PR DESCRIPTION
The rvs method accepts `size` parameters with more dimensions than the dimensions of the broadcast parameters.    E.g.
```
In [46]: from scipy.stats import hypergeom

In [47]: hypergeom.rvs(50, 30, [10, 20], size=(6, 2))  # Broadcast shape is (2,), `size` is (6, 2)`.
Out[47]: 
array([[ 7, 11],
       [ 8, 13],
       [ 6, 13],
       [ 8, 13],
       [ 6, 12],
       [ 2, 11]])
```
This requires jumping through some hoops when the core method available only returns a 1-d array of variates for scalar parameters.  This has been implemented before, in `truncnorm._rvs` and `invgauss._rvs`.  I use the same method here, with the necessary tweaks for four parameters and an integer array output.  (Eventually, this should be factored out into a utility function, but we don't have to do that in this PR.)

With this change,
```
In [51]: from scipy.stats import fnch

In [52]: fnch.rvs(50, [[15], [30]], 20, [0.5, 1, 2], size=(4, 2, 3))
array([[[ 2,  5,  7],
        [12, 13, 14]],

       [[ 5,  6,  8],
        [ 8, 13, 15]],

       [[ 3,  8,  8],
        [ 8, 14, 15]],

       [[ 8,  3, 11],
        [11, 10, 15]]])
```