### PR TITLE
FIX: resolve Generator objects if numpy.random has them

### DIFF
--- a/scipy/stats/_generate_pyx.py
+++ b/scipy/stats/_generate_pyx.py
@@ -1,11 +1,10 @@
 import pathlib
 
 def make_biasedurn():
-    # numpy's random C API changes between 17 and 18
-    from numpy import __version__ as __numpy_version__
-    from scipy._lib import _pep440
-    NPY_OLD = _pep440.parse(__numpy_version__) < _pep440.Version('1.18')
-    del _pep440
+    # numpy's random C API changes between 1.17 and 1.18
+    import numpy as np
+    ver = np.__version__.split('.')
+    NPY_OLD = (int(ver[0]) <= 1) and (int(ver[1]) < 18)
     biasedurn_base = (pathlib.Path(__file__).parent / 'biasedurn').absolute()
     with open(biasedurn_base.with_suffix('.pyx.templ'), 'r') as src:
         contents = src.read()

--- a/scipy/stats/_generate_pyx.py
+++ b/scipy/stats/_generate_pyx.py
@@ -1,9 +1,11 @@
 import pathlib
-import numpy as np
 
 def make_biasedurn():
     # numpy's random C API changes between 17 and 18
-    NPY_OLD = int(np.__version__.split('.')[1]) < 18
+    from numpy import __version__ as __numpy_version__
+    from scipy._lib import _pep440
+    NPY_OLD = _pep440.parse(__numpy_version__) < _pep440.Version('1.18')
+    del _pep440
     biasedurn_base = (pathlib.Path(__file__).parent / 'biasedurn').absolute()
     with open(biasedurn_base.with_suffix('.pyx.templ'), 'r') as src:
         contents = src.read()

--- a/scipy/stats/biasedurn.pyx.templ
+++ b/scipy/stats/biasedurn.pyx.templ
@@ -107,8 +107,12 @@ cdef class _PyStochasticLib3:
                 rng = np.random.RandomState(random_state)
             elif isinstance(random_state, np.random.RandomState):
                 rng = random_state
+            elif hasattr(np.random, 'Generator') and isinstance(random_state, np.random.Generator):
+                # if we are building in a compatibility mode, we may need
+                # to resolve newer numpy Generator objects
+                rng = random_state
             else:
-                raise TypeError('random_state is not one of None, int, RandomState')
+                raise TypeError('random_state is not one of None, int, RandomState, or Generator')
             global _glob_rng
             _glob_rng = rng
     ELSE:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

gh-13330

#### What does this implement/fix?
<!--Please explain your changes.-->

- responds to Warren's comment about numpy version comparison
- resolve `numpy.random.Generator` for wheels
    - wheels are built using the lowest supported numpy, so we should be good to go here

#### Additional information
<!--Any additional information you think is important.-->