### PR TITLE
FIX: update NPY_OLD logic; add normal generator; replace c_fnch with …

### DIFF
--- a/scipy/stats/_generate_pyx.py
+++ b/scipy/stats/_generate_pyx.py
@@ -1,15 +1,22 @@
 import pathlib
 
-def make_biasedurn():
-    # numpy's random C API changes between 1.17 and 1.18
+def isNPY_OLD():
+    '''
+    A new random C API was added in 1.18 and became stable in 1.19.
+    Prefer the new random C API when building with recent numpy.
+    '''
     import numpy as np
-    ver = np.__version__.split('.')
-    NPY_OLD = (int(ver[0]) <= 1) and (int(ver[1]) < 18)
+    ver = tuple(int(num) for num in np.__version__.split('.')[:2])
+    return ver < (1, 19)
+
+
+def make_biasedurn():
+    '''Substitute True/False values for NPY_OLD Cython build variable.'''
     biasedurn_base = (pathlib.Path(__file__).parent / 'biasedurn').absolute()
     with open(biasedurn_base.with_suffix('.pyx.templ'), 'r') as src:
         contents = src.read()
     with open(biasedurn_base.with_suffix('.pyx'), 'w') as dest:
-        dest.write(contents.format(NPY_OLD=str(bool(NPY_OLD))))
+        dest.write(contents.format(NPY_OLD=str(bool(isNPY_OLD()))))
 
 
 if __name__ == '__main__':

--- a/scipy/stats/biasedurn.pxd
+++ b/scipy/stats/biasedurn.pxd
@@ -24,3 +24,4 @@ cdef extern from "biasedurn/stocc.h" nogil:
         int FishersNCHyp (int n, int m, int N, double odds) except +
         int WalleniusNCHyp (int n, int m, int N, double odds) except +
         double(*next_double)()
+        double(*next_normal)(const double m, const double s)

--- a/scipy/stats/biasedurn.pyx.templ
+++ b/scipy/stats/biasedurn.pyx.templ
@@ -11,6 +11,21 @@ IF not NPY_OLD:
     from numpy.random cimport bitgen_t
     from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_IsValid
 
+    # If this were C code we could do this:
+    #     from numpy.random.c_distributions cimport random_normal
+    # But this is C++, so we need to wrap the include with an extern "C"
+    # to prevent name-mangling -- this is probably a Cython bug.
+    # (Note: the double curly braces are due to the use of a format
+    #  string in _generate_pyx.py for simple substitutions -- they will
+    #  be replaced by single curly braces in the generated pyx file)
+    cdef extern from *:
+        """
+        extern "C" {{
+          #include "numpy/random/distributions.h"
+        }}
+        """
+        double random_normal(bitgen_t*, double, double) nogil
+
 cdef class _PyFishersNCHypergeometric:
     cdef unique_ptr[CFishersNCHypergeometric] c_fnch
 
@@ -36,26 +51,26 @@ cdef class _PyFishersNCHypergeometric:
 
 
 cdef class _PyWalleniusNCHypergeometric:
-    cdef unique_ptr[CWalleniusNCHypergeometric] c_fnch
+    cdef unique_ptr[CWalleniusNCHypergeometric] c_wnch
 
     def __cinit__(self, int n, int m, int N, double odds, double accuracy):
-        self.c_fnch = unique_ptr[CWalleniusNCHypergeometric](new CWalleniusNCHypergeometric(n, m, N, odds, accuracy))
+        self.c_wnch = unique_ptr[CWalleniusNCHypergeometric](new CWalleniusNCHypergeometric(n, m, N, odds, accuracy))
 
     def mode(self):
-        return self.c_fnch.get().mode()
+        return self.c_wnch.get().mode()
 
     def mean(self):
-        return self.c_fnch.get().mean()
+        return self.c_wnch.get().mean()
 
     def variance(self):
-        return self.c_fnch.get().variance()
+        return self.c_wnch.get().variance()
 
     def probability(self, int x):
-        return self.c_fnch.get().probability(x)
+        return self.c_wnch.get().probability(x)
 
     def moments(self):
         cdef double mean, var
-        self.c_fnch.get().moments(&mean, &var)
+        self.c_wnch.get().moments(&mean, &var)
         return mean, var
 
 
@@ -64,11 +79,17 @@ IF NPY_OLD:
     cdef double next_double() nogil:
         with gil:
             return _glob_rng.uniform()
+    cdef double next_normal(const double m, const double s) nogil:
+        with gil:
+            return _glob_rng.normal(m, s)
 ELSE:
     cdef bitgen_t* _glob_rng
     cdef double next_double() nogil:
         global _glob_rng
-        return _glob_rng.next_double(_glob_rng.state);
+        return _glob_rng.next_double(_glob_rng.state)
+    cdef double next_normal(const double m, const double s) nogil:
+        global _glob_rng
+        return random_normal(_glob_rng, m, s)
 
     cdef object make_rng(random_state=None):
         # get a bit_generator object
@@ -93,6 +114,7 @@ cdef class _PyStochasticLib3:
     def __cinit__(self):
         self.c_sl3 = unique_ptr[StochasticLib3](new StochasticLib3(0))
         self.c_sl3.get().next_double = &next_double
+        self.c_sl3.get().next_normal = &next_normal
 
     def Random(self):
         return self.c_sl3.get().Random()

--- a/scipy/stats/biasedurn/impls.cpp
+++ b/scipy/stats/biasedurn/impls.cpp
@@ -5,7 +5,7 @@
 #include "stocc.h"
 
 double StochasticLib1::Normal(double m, double s) {
-  throw std::runtime_error("No normal generator found!");
+  return next_normal(m, s);
 }
 
 void FatalError(const char* msg) {

--- a/scipy/stats/biasedurn/stocR.h
+++ b/scipy/stats/biasedurn/stocR.h
@@ -6,12 +6,19 @@
 struct StocRBase {
 
   double(*next_double)();
+  double(*next_normal)(const double m, const double s);
 
-  StocRBase() : next_double(NULL) {}
-  StocRBase(int seed) : next_double(NULL) {}
+  StocRBase() : next_double(NULL), next_normal(NULL) {}
+  StocRBase(int seed) : next_double(NULL), next_normal(NULL) {}
 
   double Random() {
     return next_double();
+  }
+
+  double Normal(double m, double s) {
+    // Also see impls.cpp for the StochasticLib1 implementation
+    // (should be identical to this)
+    return next_normal(m, s);
   }
 };
 

--- a/scipy/stats/setup.py
+++ b/scipy/stats/setup.py
@@ -39,6 +39,10 @@ def configuration(parent_package='',top_path=None):
 
     # add BiasedUrn module
     config.add_data_files('biasedurn.pxd')
+    from _generate_pyx import isNPY_OLD
+    NPY_OLD = isNPY_OLD()
+    biasedurn_libs = [] if NPY_OLD else ['npyrandom']
+    biasedurn_libdirs = [] if NPY_OLD else [join(np.get_include(), '..', '..', 'random', 'lib')]
     ext = config.add_extension(
         'biasedurn',
         sources=[
@@ -49,6 +53,8 @@ def configuration(parent_package='',top_path=None):
             'biasedurn/stoc1.cpp',
             'biasedurn/stoc3.cpp'],
         include_dirs=[np.get_include()],
+        library_dirs=biasedurn_libdirs,
+        libraries=biasedurn_libs,
         define_macros=[('R_BUILD', None)],
         language='c++',
         extra_compile_args=['-Wno-narrowing'] if system() == 'Darwin' else [],


### PR DESCRIPTION
…c_wnch

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/pull/13330

#### What does this implement/fix?
<!--Please explain your changes.-->

- updates `NPY_OLD` logic
    - separates into function (because it's needed multiple places now)
    - uses tuple comparisons
    - use stable new random C API from numpy >= 1.19
- replaces `c_fnch` with `c_wnch`
- passes the `random_normal` function through to the stoc classes

#### Additional information
<!--Any additional information you think is important.-->

- found an interesting Cython bug (?) when using the numpy `c_distribution` C API.  C++ name mangling was causing the linker to not find the symbols in the npyrandom static library.  Explicitly adding an `extern "C"` guard resolved the issue