### PR TITLE
MAINT: raise a warning when `loguniform.fit` or `reciprocal.fit` is called

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3,6 +3,7 @@
 # Author:  Travis Oliphant  2002-2011 with contributions from
 #          SciPy Developers 2004-2011
 #
+from textwrap import dedent
 import warnings
 from collections.abc import Iterable
 from functools import wraps
@@ -7274,6 +7275,33 @@ class reciprocal_gen(rv_continuous):
 
     def _entropy(self, a, b):
         return 0.5*np.log(a*b)+np.log(np.log(b*1.0/a))
+
+    @extend_notes_in_docstring(rv_continuous, notes="""\
+        `loguniform`/`reciprocal` is over-parameterized and the `fit` method
+        might fail to find a unique solution. It is recommended to use the
+        `log_uniform.fit` method instead which is parametrized using
+        `c = b / a`. To get back the `a`, `b` parametrization from `c`,
+        use `a = fscale`, `b = c * a`, `loc = floc`, and `scale = 1`:
+
+        >>> from scipy import stats
+        >>> rvs = stats.loguniform.rvs(0.1, 1, size=1000)
+        >>> c, floc, fscale = stats.log_uniform.fit(rvs)
+        >>> a = fscale
+        >>> b = c * a
+        >>> loc, scale = floc, 1
+        >>> a, b, loc, scale
+        (0.13212701233902052, 1.031758782148188, -0.03195303401387435, 1)  # may vary  # noqa: E501
+        >>> dist = stats.loguniform(a, b, loc=loc, scale=scale)
+        \n\n""")
+    def fit(self, data, *args, **kwds):
+        warnings.warn(" ".join(dedent("""\
+        `loguniform`/`reciprocal` is over-parameterized and the `fit` method
+        might fail to find a unique solution. It is recommended to use the
+        `log_uniform.fit` method instead which is parametrized using
+        `c = b / a`. To get back the `a`, `b` parametrization from `c`,
+        use `a = fscale`, `b = c * a`, `loc = floc`, and `scale = 1`.
+        """).split("\n")), UserWarning, stacklevel=2)
+        return super().fit(data, *args, **kwds)
 
 
 loguniform = reciprocal_gen(name="loguniform")

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3,7 +3,6 @@
 # Author:  Travis Oliphant  2002-2011 with contributions from
 #          SciPy Developers 2004-2011
 #
-from textwrap import dedent
 import warnings
 from collections.abc import Iterable
 from functools import wraps
@@ -7276,31 +7275,29 @@ class reciprocal_gen(rv_continuous):
     def _entropy(self, a, b):
         return 0.5*np.log(a*b)+np.log(np.log(b*1.0/a))
 
-    @extend_notes_in_docstring(rv_continuous, notes="""\
-        `loguniform`/`reciprocal` is over-parameterized and the `fit` method
-        might fail to find a unique solution. It is recommended to use the
-        `log_uniform.fit` method instead which is parametrized using
-        `c = b / a`. To get back the `a`, `b` parametrization from `c`,
-        use `a = fscale`, `b = c * a`, `loc = floc`, and `scale = 1`:
+    fit_note = """\
+        `loguniform`/`reciprocal` is over-parameterized, so `fit` does not
+        provide a unique solution. Consider using `log_uniform` instead,
+        which is parametrized using `c = b / a`. After fitting, the `a`, `b`
+        parametrization can be obtained from the `c` parameterization using
+        `a = scale`, `b = c * a`, `loc = loc`, and `scale = 1`."""
 
+    fit_example = """\n
         >>> from scipy import stats
         >>> rvs = stats.loguniform.rvs(0.1, 1, size=1000)
-        >>> c, floc, fscale = stats.log_uniform.fit(rvs)
-        >>> a = fscale
+        >>> c, loc, scale = stats.log_uniform.fit(rvs)
+        >>> a = scale
         >>> b = c * a
-        >>> loc, scale = floc, 1
+        >>> loc, scale = loc, 1
         >>> a, b, loc, scale
-        (0.13212701233902052, 1.031758782148188, -0.03195303401387435, 1)  # may vary  # noqa: E501
+        (0.13212701233902052, 1.031758782148188, -0.03195303401387435, 1)
         >>> dist = stats.loguniform(a, b, loc=loc, scale=scale)
-        \n\n""")
+        \n"""
+
+    compact_note = " ".join(fit_note.split())
+    @extend_notes_in_docstring(rv_continuous, notes=fit_note+fit_example)
     def fit(self, data, *args, **kwds):
-        warnings.warn(" ".join(dedent("""\
-        `loguniform`/`reciprocal` is over-parameterized and the `fit` method
-        might fail to find a unique solution. It is recommended to use the
-        `log_uniform.fit` method instead which is parametrized using
-        `c = b / a`. To get back the `a`, `b` parametrization from `c`,
-        use `a = fscale`, `b = c * a`, `loc = floc`, and `scale = 1`.
-        """).split("\n")), UserWarning, stacklevel=2)
+        warnings.warn(self.compact_note, UserWarning, stacklevel=2)
         return super().fit(data, *args, **kwds)
 
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -55,7 +55,8 @@ skip_fit_test_mle = ['exponpow', 'exponweib', 'gausshyper', 'genexpon',
                      'kappa4', 'ksone', 'kstwo', 'kstwobign', 'mielke', 'ncf',
                      'nct', 'powerlognorm', 'powernorm', 'recipinvgauss',
                      'trapezoid', 'vonmises', 'vonmises_line', 'levy_stable',
-                     'rv_histogram_instance', 'studentized_range']
+                     'rv_histogram_instance', 'studentized_range',
+                     'loguniform', 'reciprocal']
 
 # these were really slow in `test_fit`.py.
 # note that this list is used to skip both fit_test and fit_fix tests
@@ -68,6 +69,8 @@ slow_fit_test_mm = ['argus', 'exponpow', 'exponweib', 'gausshyper', 'genexpon',
 # the first list fails due to non-finite distribution moments encountered
 # most of the rest fail due to integration warnings
 # pearson3 is overriden as not implemented due to gh-11746
+# loguniform and reciprocal are over-parametrized so the fit method raises
+# a user warning.
 fail_fit_test_mm = (['alpha', 'betaprime', 'bradford', 'burr', 'burr12',
                      'cauchy', 'crystalball', 'f', 'fisk', 'foldcauchy',
                      'genextreme', 'genpareto', 'halfcauchy', 'invgamma',
@@ -76,7 +79,8 @@ fail_fit_test_mm = (['alpha', 'betaprime', 'bradford', 'burr', 'burr12',
                      'tukeylambda', 'invweibull']
                      + ['genhyperbolic', 'johnsonsu', 'ksone', 'kstwo',
                         'nct', 'pareto', 'powernorm', 'powerlognorm']
-                     + ['pearson3'])
+                     + ['pearson3']
+                     + ['loguniform', 'reciprocal'])
 skip_fit_test = {"MLE": skip_fit_test_mle,
                  "MM": slow_fit_test_mm + fail_fit_test_mm}
 
@@ -87,10 +91,12 @@ skip_fit_fix_test_mle = ['burr', 'exponpow', 'exponweib', 'gausshyper',
                          'levy_stable', 'mielke', 'ncf', 'ncx2',
                          'powerlognorm', 'powernorm', 'rdist', 'recipinvgauss',
                          'trapezoid', 'vonmises', 'vonmises_line',
-                         'studentized_range']
+                         'studentized_range', 'loguniform', 'reciprocal']
 # the first list fails due to non-finite distribution moments encountered
 # most of the rest fail due to integration warnings
 # pearson3 is overriden as not implemented due to gh-11746
+# loguniform and reciprocal are over-parametrized so the fit method raises
+# a user warning.
 fail_fit_fix_test_mm = (['alpha', 'betaprime', 'burr', 'burr12', 'cauchy',
                          'crystalball', 'f', 'fisk', 'foldcauchy',
                          'genextreme', 'genpareto', 'halfcauchy', 'invgamma',
@@ -99,7 +105,8 @@ fail_fit_fix_test_mm = (['alpha', 'betaprime', 'burr', 'burr12', 'cauchy',
                          'invweibull']
                          + ['genhyperbolic', 'johnsonsu', 'ksone', 'kstwo',
                             'pareto', 'powernorm', 'powerlognorm']
-                         + ['pearson3'])
+                         + ['pearson3']
+                         + ['loguniform', 'reciprocal'])
 skip_fit_fix_test = {"MLE": skip_fit_fix_test_mle,
                      "MM": slow_fit_test_mm + fail_fit_fix_test_mm}
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3918,7 +3918,8 @@ class TestFitMethod:
         np.random.seed(1234)
 
     # skip these b/c deprecated, or only loc and scale arguments
-    fitSkipNonFinite = ['expon', 'norm', 'uniform']
+    fitSkipNonFinite = ['expon', 'norm', 'uniform', 'loguniform',
+                        'reciprocal']
 
     @pytest.mark.parametrize('dist,args', distcont)
     def test_fit_w_non_finite_data_values(self, dist, args):


### PR DESCRIPTION
#### Reference issue

scipy#15889

#### What does this implement/fix?

Raise a `UserWarning` when the fit method of the `loguniform` and `reciprocal` distributions is called. Instead of deprecating the `loguniform` and `reciprocal` distributions, I think moving users away from the `[loguniform|reciprocal].fit` method is more user friendly. `loguniform` and `reciprocal` still provide useful functionality and canonical parametrization for new users or users who don't use the `fit` method.