### PR TITLE
ENH: stats: use Boost implementation of skewnorm cdf/ppf

### DIFF
--- a/scipy/stats/_boost/__init__.py
+++ b/scipy/stats/_boost/__init__.py
@@ -39,3 +39,9 @@ from scipy.stats._boost.nct_ufunc import (
     _nct_isf, _nct_mean, _nct_variance,
     _nct_skewness, _nct_kurtosis_excess,
 )
+
+from scipy.stats._boost.skewnorm_ufunc import (
+    _skewnorm_pdf, _skewnorm_cdf, _skewnorm_sf, _skewnorm_ppf,
+    _skewnorm_isf, _skewnorm_mean, _skewnorm_variance,
+    _skewnorm_skewness, _skewnorm_kurtosis_excess,
+)

--- a/scipy/stats/_boost/include/_info.py
+++ b/scipy/stats/_boost/include/_info.py
@@ -16,6 +16,7 @@ _klass_mapper = {
     'non_central_f': _KlassMap('ncf', ('dfn', 'dfd', 'nc')),
     'non_central_chi_squared': _KlassMap('ncx2', ('df', 'nc')),
     'non_central_t': _KlassMap('nct', ('df', 'nc')),
+    'skew_normal': _KlassMap('skewnorm', ('loc', 'scale', 'a',)),
 }
 
 # functions that take ctor params and parameter "x"

--- a/scipy/stats/_boost/meson.build
+++ b/scipy/stats/_boost/meson.build
@@ -60,8 +60,16 @@ ncx2_ufunc = py3.extension_module('ncx2_ufunc',
   subdir: 'scipy/stats/_boost'
 )
 
-ncf_ufunc = py3.extension_module('nct_ufunc',
+nct_ufunc = py3.extension_module('nct_ufunc',
   nct_ufunc_pyx,
+  include_directories: [include, inc_np, inc_boost],
+  cpp_args: [cpp_args, cython_cpp_args],
+  install: true,
+  subdir: 'scipy/stats/_boost'
+)
+
+skewnorm_ufunc = py3.extension_module('skewnorm_ufunc',
+  skewnorm_ufunc_pyx,
   include_directories: [include, inc_np, inc_boost],
   cpp_args: [cpp_args, cython_cpp_args],
   install: true,

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -120,7 +120,8 @@ _stats_gen_pyx = custom_target('_stats_gen_pyx',
     'unuran_wrapper.pyx',  # 7 (used in stats/_unuran)
     'ncf_ufunc.pyx',  # 8 (S_B)
     'ncx2_ufunc.pyx',  # 9 (S_B)
-    'nct_ufunc.pyx'  # 10 (S_B)
+    'nct_ufunc.pyx',  # 10 (S_B)
+    'skewnorm_ufunc.pyx',  # 11 (S_B)
   ],
   input: '_generate_pyx.py',
   command: [py3, '@INPUT@', '-o', '@OUTDIR@'],
@@ -141,6 +142,7 @@ nbinom_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[5])
 ncf_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[8])
 ncx2_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[9])
 nct_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[10])
+skewnorm_ufunc_pyx = cython_stats_gen_cpp.process(_stats_gen_pyx[11])
 
 # Extra dependency from _lib
 unuran_wrap_pyx = lib_cython_gen.process(_stats_gen_pyx[7])

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -59,7 +59,7 @@ skip_fit_test_mle = ['exponpow', 'exponweib', 'gausshyper', 'genexpon',
 # note that this list is used to skip both fit_test and fit_fix tests
 slow_fit_test_mm = ['argus', 'exponpow', 'exponweib', 'gausshyper', 'genexpon',
                     'genhalflogistic', 'halfgennorm', 'gompertz', 'johnsonsb',
-                    'kappa4', 'kstwobign', 'recipinvgauss', 'skewnorm',
+                    'kappa4', 'kstwobign', 'recipinvgauss',
                     'trapezoid', 'truncexpon', 'vonmises', 'vonmises_line',
                     'studentized_range']
 # pearson3 fails due to something weird

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -38,7 +38,7 @@ DECIMAL = 5  # specify the precision of the tests  # increased from 0 to 5
 # For skipping test_cont_basic
 distslow = ['recipinvgauss', 'vonmises', 'kappa4', 'vonmises_line',
             'gausshyper', 'norminvgauss', 'geninvgauss', 'genhyperbolic',
-            'truncnorm', 'skewnorm', 'truncweibull_min']
+            'truncnorm', 'truncweibull_min']
 
 # distxslow are sorted by speed (very slow to slow)
 distxslow = ['studentized_range', 'kstwo', 'ksone', 'wrapcauchy', 'genexpon']

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -57,7 +57,7 @@ mm_failing_fits = ['alpha', 'betaprime', 'burr', 'burr12', 'cauchy', 'chi',
 # not sure if these fail, but they caused my patience to fail
 mm_slow_fits = ['argus', 'exponpow', 'exponweib', 'gausshyper', 'genexpon',
                 'genhalflogistic', 'halfgennorm', 'gompertz', 'johnsonsb',
-                'kappa4', 'kstwobign', 'recipinvgauss', 'skewnorm',
+                'kappa4', 'kstwobign', 'recipinvgauss',
                 'truncexpon', 'vonmises', 'vonmises_line']
 
 failing_fits = {"MM": mm_failing_fits + mm_slow_fits, "MLE": mle_failing_fits}

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -188,7 +188,7 @@ def cases_test_fit():
                       'alpha', 't', 'crystalball', 'fatiguelife', 'nakagami',
                       'kstwobign', 'gompertz', 'dweibull', 'lomax', 'invgauss',
                       'recipinvgauss', 'chi', 'foldcauchy', 'powernorm',
-                      'gennorm', 'skewnorm', 'randint', 'genextreme'}
+                      'gennorm', 'randint', 'genextreme'}
     xslow_basic_fit = {'nchypergeom_fisher', 'nchypergeom_wallenius',
                        'gausshyper', 'genexpon', 'gengamma', 'genhyperbolic',
                        'geninvgauss', 'tukeylambda', 'skellam', 'ncx2',


### PR DESCRIPTION
@mckib2 Boost's skewnorm distribution accepts `location` and `scale`. What is the best way to handle that in `_info.py`? `a` is really the third argument in Boost's implementation.