### PR TITLE
ENH: stats.multivariate: introduce `Covariance` class and subclasses

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -487,6 +487,7 @@ from ._rvs_sampling import rvs_ratio_uniforms
 from ._page_trend_test import page_trend_test
 from ._mannwhitneyu import mannwhitneyu
 from ._fit import fit
+from ._covariance import *
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -1,0 +1,201 @@
+from functools import cached_property
+
+import numpy as np
+from scipy import linalg
+from . import _multivariate
+
+__all__ = ["Covariance", "CovViaDiagonal", "CovViaPrecision",
+           "CovViaEigendecomposition", "CovViaCov", "CovViaPSD"]
+
+
+class Covariance():
+    """
+    Representation of a covariance matrix as needed by multivariate_normal
+    """
+
+    def whiten(self, x):
+        """
+        Right multiplication by the left square root of the precision matrix.
+        """
+        return self._whiten(x)
+
+    @cached_property
+    def log_pdet(self):
+        """
+        Log of the pseudo-determinant of the covariance matrix
+        """
+        return self._log_pdet
+
+    @cached_property
+    def rank(self):
+        """
+        Rank of the covariance matrix
+        """
+        return self._rank
+
+    @cached_property
+    def A(self):
+        """
+        Explicit representation of the covariance matrix
+        """
+        return self._A
+
+    @cached_property
+    def dimensionality(self):
+        """
+        Dimensionality of the vector space
+        """
+        return self._dimensionality
+
+    def _validate_matrix(self, A, name):
+        A = np.atleast_2d(A)
+        m, n = A.shape[-2:]
+        if m != n or A.ndim != 2 or not np.issubdtype(A.dtype, np.number):
+            message = (f"The input `{name}` must be a square, "
+                       "two-dimensional array of numbers.")
+            raise ValueError(message)
+        return A
+
+    def _validate_vector(self, A, name):
+        A = np.atleast_1d(A)
+        if A.ndim != 1 or not np.issubdtype(A.dtype, np.number):
+            message = (f"The input `{name}` must be a one-dimensional array "
+                       "of numbers.")
+            raise ValueError(message)
+        return A
+
+
+class CovViaDiagonal(Covariance):
+    """
+    Representation of a covariance provided via the diagonal
+    """
+
+    def __init__(self, diagonal):
+        diagonal = self._validate_vector(diagonal, 'diagonal')
+
+        i_positive = diagonal > 0
+        positive_diagonal = diagonal[i_positive]
+        self._log_pdet = np.sum(np.log(positive_diagonal))
+
+        psuedo_reciprocals = np.zeros_like(diagonal, dtype=np.float64)
+        psuedo_reciprocals[i_positive] = 1 / np.sqrt(positive_diagonal)
+
+        self._LP = psuedo_reciprocals
+        self._rank = positive_diagonal.shape[-1]
+        self._A = np.diag(diagonal)
+        self._dimensionality = diagonal.shape[-1]
+        self.i_positive = i_positive
+
+    def _whiten(self, x):
+        return x * self._LP
+
+    def _support_mask(self, x):
+        """
+        Check whether x lies in the support of the distribution.
+        """
+        return np.all(x[..., ~self.i_positive] == 0, axis=-1)
+
+
+class CovViaPrecision(Covariance):
+    """
+    Representation of a covariance provided via the precision matrix
+    """
+
+    def __init__(self, precision, covariance=None):
+        precision = self._validate_matrix(precision, 'precision')
+        if covariance is not None:
+            covariance = self._validate_matrix(precision, 'covariance')
+
+        self._LP = np.linalg.cholesky(precision)
+        self._log_pdet = -2*np.log(np.diag(self._LP)).sum(axis=-1)
+        self._rank = precision.shape[-1]  # must be full rank in invertible
+        self._precision = precision
+        self._covariance = covariance
+        self._dimensionality = self._rank
+
+    def _whiten(self, x):
+        return x @ self._LP
+
+    @cached_property
+    def _A(self):
+        return (np.linalg.inv(self._precision) if self._covariance is None
+                else self._covariance)
+
+
+class CovViaEigendecomposition(Covariance):
+    """
+    Representation of a covariance provided via eigenvalues and eigenvectors
+    """
+
+    def __init__(self, eigenvalues, eigenvectors):
+        eigenvalues = self._validate_vector(eigenvectors, 'eigenvalues')
+        eigenvectors = self._validate_matrix(eigenvectors, 'eigenvectors')
+
+        i_positive = eigenvalues > 0
+        positive_eigenvalues = eigenvalues[i_positive]
+        self._log_pdet = np.sum(np.log(positive_eigenvalues))
+
+        psuedo_reciprocals = np.zeros_like(eigenvalues)
+        psuedo_reciprocals[i_positive] = 1 / np.sqrt(positive_eigenvalues)
+
+        self._LP = eigenvectors * psuedo_reciprocals
+        self._rank = positive_eigenvalues.shape[-1]
+        self._w = eigenvalues
+        self._v = eigenvectors
+        self._dimensionality = eigenvalues.shape[-1]
+        self.i_positive = i_positive
+        self._null_basis = eigenvectors[..., ~i_positive]
+        self._eps = _multivariate._eigvalsh_to_eps(eigenvalues) * 10**3
+
+    def _whiten(self, x):
+        return x @ self._LP
+
+    @cached_property
+    def _A(self):
+        return (self._v * self._w) @ self._v.swapaxes(-2, -1)
+
+    def _support_mask(self, x):
+        """
+        Check whether x lies in the support of the distribution.
+        """
+        residual = np.linalg.norm(x @ self._null_basis, axis=-1)
+        in_support = residual < self._eps
+        return in_support
+
+
+class CovViaCov(Covariance):
+    """
+    Representation of a covariance provided via the precision matrix
+    """
+
+    def __init__(self, cov):
+        cov = self._validate_matrix(cov, 'cov')
+
+        self._factor = np.linalg.cholesky(cov.T[::-1, ::-1])[::-1, ::-1]
+        self._log_pdet = 2*np.log(np.diag(self._factor)).sum(axis=-1)
+        self._rank = cov.shape[-1]  # must be full rank for cholesky
+        self._A = cov
+        self._dimensionality = self._rank
+
+    def _whiten(self, x):
+        return linalg.solve_triangular(self._factor, x.T, lower=False).T
+
+
+class CovViaPSD(Covariance):
+    """
+    Representation of a covariance provided via an instance of _PSD
+    """
+
+    def __init__(self, psd):
+        self._LP = psd.U
+        self._log_pdet = psd.log_pdet
+        self._rank = psd.rank
+        self._A = psd._M
+        self._dimensionality = psd._M.shape[-1]
+        self._psd = psd
+
+    def _whiten(self, x):
+        return x @ self._LP
+
+    def _support_mask(self, x):
+        return self._psd._support_mask(x)

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -56,8 +56,9 @@ def _solve_triangular(A, x, *args, **kwds):
 
     # If dimension of A is non-singleton, we need to loop over it. ("loop")
     # Move all of these to the front.
-    # Remaining dimensions will end up next to -2. We'll combine them with -2 and
-    # act over them in a multiple-RHS single call to `solve_triangular`. ("mrhs")
+    # Remaining dimensions will end up next to -2. We'll combine them with
+    # -2 and act over them in a multiple-RHS single call to
+    # `solve_triangular`. ("mrhs")
     i_loop = np.array(A.shape[:-2]) > 1
     j_loop = dimnums[i_loop]
     n_loop_dims = len(j_loop)
@@ -275,7 +276,7 @@ class CovViaEigendecomposition(Covariance):
 
     @cached_property
     def _A(self):
-        return (self._v * self._w) @ self._v.swapaxes(-2, -1)
+        return (self._v * self._w[..., np.newaxis, :]) @ _T(self._v)
 
     def _support_mask(self, x):
         """

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -128,14 +128,14 @@ class Covariance():
         """
         Log of the pseudo-determinant of the covariance matrix
         """
-        return self._log_pdet
+        return np.array(self._log_pdet, dtype=float)[()]
 
     @cached_property
     def rank(self):
         """
         Rank of the covariance matrix
         """
-        return self._rank
+        return np.array(self._rank, dtype=int)[()]
 
     @cached_property
     def A(self):
@@ -149,7 +149,14 @@ class Covariance():
         """
         Dimensionality of the vector space
         """
-        return self._dimensionality
+        return np.array(self._dimensionality, dtype=int)[()]
+
+    @cached_property
+    def shape(self):
+        """
+        Shape of the covariance array
+        """
+        return self._shape
 
     def _validate_matrix(self, A, name):
         A = np.atleast_2d(A)
@@ -192,6 +199,7 @@ class CovViaDiagonal(Covariance):
         self._A = np.apply_along_axis(np.diag, -1, diagonal)
         self._dimensionality = diagonal.shape[-1]
         self._i_zero = i_zero
+        self._shape = self._A.shape
         self._allow_singular = True
 
     def _whiten(self, x):
@@ -223,6 +231,7 @@ class CovViaPrecision(Covariance):
         self._precision = precision
         self._covariance = covariance
         self._dimensionality = self._rank
+        self._shape = precision.shape
         self._allow_singular = False
 
     def _whiten(self, x):
@@ -267,6 +276,7 @@ class CovViaEigendecomposition(Covariance):
         self._w = eigenvalues
         self._v = eigenvectors
         self._dimensionality = eigenvalues.shape[-1]
+        self._shape = eigenvectors.shape
         self._null_basis = eigenvectors * np.expand_dims(i_zero, -2)
         self._eps = _multivariate._eigvalsh_to_eps(eigenvalues) * 10**3
         self._allow_singular = True
@@ -300,6 +310,7 @@ class CovViaCov(Covariance):
         self._rank = cov.shape[-1]  # must be full rank for cholesky
         self._A = cov
         self._dimensionality = self._rank
+        self._shape = cov.shape
         self._allow_singular = False
 
     def _whiten(self, x):
@@ -318,6 +329,7 @@ class CovViaPSD(Covariance):
         self._rank = psd.rank
         self._A = psd._M
         self._dimensionality = psd._M.shape[-1]
+        self._shape = psd._M.shape
         self._psd = psd
         self._allow_singular = False  # by default
 

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -151,7 +151,7 @@ class CovViaPrecision(Covariance):
             covariance = self._validate_matrix(precision, 'covariance')
 
         self._LP = np.linalg.cholesky(precision)
-        self._log_pdet = -2*np.log(np.diag(self._LP)).sum(axis=-1)
+        self._log_pdet = -2*np.log(_extract_diag(self._LP)).sum(axis=-1)
         self._rank = precision.shape[-1]  # must be full rank in invertible
         self._precision = precision
         self._covariance = covariance

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -658,7 +658,7 @@ class multivariate_normal_gen(multi_rv_generic):
         x = self._process_quantiles(x, dim)
         if not maxpts:
             maxpts = 1000000 * dim
-        cdf = self._cdf(x, mean, cov_object.A, maxpts, abseps, releps, 
+        cdf = self._cdf(x, mean, cov_object.A, maxpts, abseps, releps,
                         lower_limit)
         # the log of a negative real is complex, and cdf can be negative
         # if lower limit is greater than upper limit
@@ -703,7 +703,8 @@ class multivariate_normal_gen(multi_rv_generic):
         x = self._process_quantiles(x, dim)
         if not maxpts:
             maxpts = 1000000 * dim
-        out = self._cdf(x, mean, cov_object.A, maxpts, abseps, releps, lower_limit)
+        out = self._cdf(x, mean, cov_object.A, maxpts, abseps, releps,
+                        lower_limit)
         return out
 
     def rvs(self, mean=None, cov=1, size=1, random_state=None):
@@ -832,7 +833,7 @@ class multivariate_normal_frozen(multi_rv_frozen):
 
     def cdf(self, x, *, lower_limit=None):
         x = self._dist._process_quantiles(x, self.dim)
-        out = self._dist._cdf(x, self.mean, self.cov_object.A, self.maxpts, 
+        out = self._dist._cdf(x, self.mean, self.cov_object.A, self.maxpts,
                               self.abseps, self.releps, lower_limit)
         return _squeeze_output(out)
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -14,7 +14,8 @@ from scipy.linalg._misc import LinAlgError
 from scipy.linalg.lapack import get_lapack_funcs
 
 from ._discrete_distns import binom
-from . import _mvn
+from . import _mvn, _covariance
+
 
 __all__ = ['multivariate_normal',
            'matrix_normal',
@@ -152,6 +153,8 @@ class _PSD:
 
     def __init__(self, M, cond=None, rcond=None, lower=True,
                  check_finite=True, allow_singular=True):
+        self._M = M
+
         # Compute the symmetric eigendecomposition.
         # Note that eigh takes care of array conversion, chkfinite,
         # and assertion that the matrix is square.
@@ -385,11 +388,23 @@ class multivariate_normal_gen(multi_rv_generic):
                                           allow_singular=allow_singular,
                                           seed=seed)
 
-    def _process_parameters(self, dim, mean, cov):
+    def _process_parameters(self, mean, cov, allow_singular=True):
         """
         Infer dimensionality from mean or covariance matrix, ensure that
         mean and covariance are full vector resp. matrix.
         """
+        if isinstance(cov, _covariance.Covariance):
+            dim = cov.dimensionality
+            mean = np.array([0.]) if mean is None else mean
+            mean = np.broadcast_to(dim)
+            return dim, mean, cov.A, cov
+        else:
+            dim, mean, cov = self._process_parameters_old(None, mean, cov)
+            psd = _PSD(cov, allow_singular=allow_singular)
+            cov_object = _covariance.CovViaPSD(psd)
+            return dim, mean, cov, cov_object
+
+    def _process_parameters_old(self, dim, mean, cov):
         # Try to infer dimensionality
         if dim is None:
             if mean is None:
@@ -463,7 +478,7 @@ class multivariate_normal_gen(multi_rv_generic):
 
         return x
 
-    def _logpdf(self, x, mean, prec_U, log_det_cov, rank):
+    def _logpdf(self, x, mean, cov_object):
         """Log of the multivariate normal probability density function.
 
         Parameters
@@ -473,13 +488,8 @@ class multivariate_normal_gen(multi_rv_generic):
             density function
         mean : ndarray
             Mean of the distribution
-        prec_U : ndarray
-            A decomposition such that np.dot(prec_U, prec_U.T)
-            is the precision matrix, i.e. inverse of the covariance matrix.
-        log_det_cov : float
-            Logarithm of the determinant of the covariance matrix
-        rank : int
-            Rank of the covariance matrix.
+        cov_object : Covariance
+            An object representing the Covariance matrix
 
         Notes
         -----
@@ -487,8 +497,9 @@ class multivariate_normal_gen(multi_rv_generic):
         called directly; use 'logpdf' instead.
 
         """
+        log_det_cov, rank = cov_object.log_pdet, cov_object.rank
         dev = x - mean
-        maha = np.sum(np.square(np.dot(dev, prec_U)), axis=-1)
+        maha = np.sum(np.square(cov_object.whiten(dev)), axis=-1)
         return -0.5 * (rank * _LOG_2PI + log_det_cov + maha)
 
     def logpdf(self, x, mean=None, cov=1, allow_singular=False):
@@ -510,12 +521,12 @@ class multivariate_normal_gen(multi_rv_generic):
         %(_mvn_doc_callparams_note)s
 
         """
-        dim, mean, cov = self._process_parameters(None, mean, cov)
+        dim, mean, cov, cov_object = self._process_parameters(mean, cov,
+                                                              allow_singular)
         x = self._process_quantiles(x, dim)
-        psd = _PSD(cov, allow_singular=allow_singular)
-        out = self._logpdf(x, mean, psd.U, psd.log_pdet, psd.rank)
-        if allow_singular and (psd.rank < dim):
-            out_of_bounds = ~psd._support_mask(x-mean)
+        out = self._logpdf(x, mean, cov_object)
+        if allow_singular and (cov_object.rank < dim):
+            out_of_bounds = ~cov_object._support_mask(x-mean)
             out[out_of_bounds] = -np.inf
         return _squeeze_output(out)
 
@@ -538,12 +549,12 @@ class multivariate_normal_gen(multi_rv_generic):
         %(_mvn_doc_callparams_note)s
 
         """
-        dim, mean, cov = self._process_parameters(None, mean, cov)
+        dim, mean, cov, cov_object = self._process_parameters(mean, cov,
+                                                              allow_singular)
         x = self._process_quantiles(x, dim)
-        psd = _PSD(cov, allow_singular=allow_singular)
-        out = np.exp(self._logpdf(x, mean, psd.U, psd.log_pdet, psd.rank))
-        if allow_singular and (psd.rank < dim):
-            out_of_bounds = ~psd._support_mask(x-mean)
+        out = np.exp(self._logpdf(x, mean, cov_object))
+        if allow_singular and (cov_object.rank < dim):
+            out_of_bounds = ~cov_object._support_mask(x-mean)
             out[out_of_bounds] = 0.0
         return _squeeze_output(out)
 
@@ -609,10 +620,9 @@ class multivariate_normal_gen(multi_rv_generic):
         .. versionadded:: 1.0.0
 
         """
-        dim, mean, cov = self._process_parameters(None, mean, cov)
+        dim, mean, cov, cov_object = self._process_parameters(mean, cov,
+                                                              allow_singular)
         x = self._process_quantiles(x, dim)
-        # Use _PSD to check covariance matrix
-        _PSD(cov, allow_singular=allow_singular)
         if not maxpts:
             maxpts = 1000000 * dim
         out = np.log(self._cdf(x, mean, cov, maxpts, abseps, releps))
@@ -647,10 +657,9 @@ class multivariate_normal_gen(multi_rv_generic):
         .. versionadded:: 1.0.0
 
         """
-        dim, mean, cov = self._process_parameters(None, mean, cov)
+        dim, mean, cov, cov_object = self._process_parameters(mean, cov,
+                                                              allow_singular)
         x = self._process_quantiles(x, dim)
-        # Use _PSD to check covariance matrix
-        _PSD(cov, allow_singular=allow_singular)
         if not maxpts:
             maxpts = 1000000 * dim
         out = self._cdf(x, mean, cov, maxpts, abseps, releps)
@@ -677,7 +686,7 @@ class multivariate_normal_gen(multi_rv_generic):
         %(_mvn_doc_callparams_note)s
 
         """
-        dim, mean, cov = self._process_parameters(None, mean, cov)
+        dim, mean, cov, cov_object = self._process_parameters(mean, cov)
 
         random_state = self._get_random_state(random_state)
         out = random_state.multivariate_normal(mean, cov, size)
@@ -700,7 +709,7 @@ class multivariate_normal_gen(multi_rv_generic):
         %(_mvn_doc_callparams_note)s
 
         """
-        dim, mean, cov = self._process_parameters(None, mean, cov)
+        dim, mean, cov, cov_object = self._process_parameters(mean, cov)
         _, logdet = np.linalg.slogdet(2 * np.pi * np.e * cov)
         return 0.5 * logdet
 
@@ -754,9 +763,8 @@ class multivariate_normal_frozen(multi_rv_frozen):
         """
         self.allow_singular = allow_singular
         self._dist = multivariate_normal_gen(seed)
-        self.dim, self.mean, self.cov = self._dist._process_parameters(
-                                                            None, mean, cov)
-        self.cov_info = _PSD(self.cov, allow_singular=allow_singular)
+        self.dim, self.mean, self.cov, self.cov_object = (
+            self._dist._process_parameters(mean, cov, allow_singular))
         if not maxpts:
             maxpts = 1000000 * self.dim
         self.maxpts = maxpts
@@ -765,10 +773,9 @@ class multivariate_normal_frozen(multi_rv_frozen):
 
     def logpdf(self, x):
         x = self._dist._process_quantiles(x, self.dim)
-        out = self._dist._logpdf(x, self.mean, self.cov_info.U,
-                                 self.cov_info.log_pdet, self.cov_info.rank)
-        if self.allow_singular and (self.cov_info.rank < self.dim):
-            out_of_bounds = ~self.cov_info._support_mask(x-self.mean)
+        out = self._dist._logpdf(x, self.mean, self.cov_object)
+        if self.allow_singular and (self.cov_object.rank < self.dim):
+            out_of_bounds = ~self.cov_object._support_mask(x-self.mean)
             out[out_of_bounds] = -np.inf
         return _squeeze_output(out)
 
@@ -796,8 +803,8 @@ class multivariate_normal_frozen(multi_rv_frozen):
             Entropy of the multivariate normal distribution
 
         """
-        log_pdet = self.cov_info.log_pdet
-        rank = self.cov_info.rank
+        log_pdet = self.cov_object.log_pdet
+        rank = self.cov_object.rank
         return 0.5 * (rank * (_LOG_2PI + 1) + log_pdet)
 
 

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -195,6 +195,7 @@ py3.install_sources([
     '_common.py',
     '_constants.py',
     '_continuous_distns.py',
+    '_covariance.py',
     '_crosstab.py',
     '_discrete_distns.py',
     '_distn_infrastructure.py',

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -44,25 +44,45 @@ def _sample_orthonormal_matrix(n):
 
 class TestCovariance:
     def test_iv(self):
-        message = "The input `diagonal` must be a one-dimensional array..."
+        message = "The input `diagonal` must be an array of numbers."
         with pytest.raises(ValueError, match=message):
-            stats.CovViaDiagonal(np.eye(2))
+            stats.CovViaDiagonal("alpaca")
 
-        message = "The input `eigenvalues` must be a one-dimensional array..."
+        message = "The input `eigenvalues` must be an array of numbers."
         with pytest.raises(ValueError, match=message):
-            stats.CovViaEigendecomposition((np.eye(2), np.eye(2)))
+            stats.CovViaEigendecomposition(("alpaca", np.eye(2)))
 
-        message = "The input `precision` must be a square, two-dimensional..."
+        message = "The input `precision` must be an array of numbers."
         with pytest.raises(ValueError, match=message):
-            stats.CovViaPrecision(np.ones(2))
+            stats.CovViaPrecision("alpaca")
 
-        message = "The input `eigenvectors` must be a square, two-..."
+        message = r"`precision.shape\[-2\]` must equal `precision.shape\[-1\]`"
         with pytest.raises(ValueError, match=message):
-            stats.CovViaEigendecomposition((np.ones(2), np.ones(2)))
+            stats.CovViaPrecision([[2], [1]])
 
-        message = "The input `cov` must be a square, two-dimensional..."
+        message = "`precision.shape` must equal `covariance.shape`."
         with pytest.raises(ValueError, match=message):
-            stats.CovViaCov(np.ones(2))
+            stats.CovViaPrecision(np.eye(3), covariance=np.eye(2))
+
+        message = "The input `eigenvectors` must be an array of numbers."
+        with pytest.raises(ValueError, match=message):
+            stats.CovViaEigendecomposition((np.eye(2), "alpaca"))
+
+        message = r"`eigenvectors.shape\[-2\]` must equal..."
+        with pytest.raises(ValueError, match=message):
+            stats.CovViaEigendecomposition((np.eye(2), [[2], [1]]))
+
+        message = "The shapes of `eigenvalues` and `eigenvectors` must be..."
+        with pytest.raises(ValueError, match=message):
+            stats.CovViaEigendecomposition((np.eye(3), np.eye(2)))
+
+        message = "The input `cov` must be an array of numbers."
+        with pytest.raises(ValueError, match=message):
+            stats.CovViaCov("alpaca")
+
+        message = r"`cov.shape\[-2\]` must equal `cov.shape\[-1\]`"
+        with pytest.raises(ValueError, match=message):
+            stats.CovViaCov([[2], [1]])
 
     def test_mean(self):
         # test the interaction between a Covariance object and mean

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -132,7 +132,7 @@ class TestMultivariateNormal:
             s = np.random.randn(n, expected_rank)
             cov = np.dot(s, s.T)
             distn = multivariate_normal(mean, cov, allow_singular=True)
-            assert_equal(distn.cov_info.rank, expected_rank)
+            assert_equal(distn.cov_object.rank, expected_rank)
 
     def test_degenerate_distributions(self):
 
@@ -163,9 +163,9 @@ class TestMultivariateNormal:
                                                allow_singular=True)
                 distn_rr = multivariate_normal(np.zeros(n), cov_rr,
                                                allow_singular=True)
-                assert_equal(distn_kk.cov_info.rank, k)
-                assert_equal(distn_nn.cov_info.rank, k)
-                assert_equal(distn_rr.cov_info.rank, k)
+                assert_equal(distn_kk.cov_object.rank, k)
+                assert_equal(distn_nn.cov_object.rank, k)
+                assert_equal(distn_rr.cov_object.rank, k)
                 pdf_kk = distn_kk.pdf(x[:k])
                 pdf_nn = distn_nn.pdf(x)
                 pdf_rr = distn_rr.pdf(y)


### PR DESCRIPTION
Explore the use of a `Covariance` class to address the need to accept alternative representations of a multivariate distribution shape matrix and avoid re-processing this matrix each time a frozen distribution method is called.