### PR TITLE
Add references per reviewer comment

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -87,3 +87,50 @@
   journal = {GitHub Issue},
   url = {https://github.com/scipy/scipy/issues/12315}
 }
+
+@misc{ye2020,
+  author = {Leihua Ye},
+  title = {Bootstrap and Statistical Inference in Python},
+  year = {2020},
+  month = {12},
+  publisher = {Medium},
+  journal = {Towards Data Science},
+  url = {https://towardsdatascience.com/a06d098a8bfd}
+}
+
+@misc{saenger2019,
+  author = {Victor Saenger},
+  title = {How To Assess Statistical Significance in Your Data with Permutation Tests},
+  year = {2019},
+  month = {10},
+  publisher = {Medium},
+  journal = {Towards Data Science},
+  url = {https://towardsdatascience.com/8bb925b2113d}
+}
+
+
+@misc{omar2021,
+  author = {Hamid Omar},
+  title = {A Guide on How to Simulate and Visualize Hypothesis Tests Using Python Code},
+  year = {2021},
+  month = {06},
+  publisher = {Medium},
+  journal = {Analytics Vidhya},
+  url = {https://medium.com/analytics-vidhya/66861e0d0f74}
+}
+
+@misc{resample2020,
+  author = {Daniel Saxton and Hans Dembinski},
+  title = {resample 1.0.0},
+  year  = {2020},
+  month = {8},
+  url   = {https://github.com/scikit-hep/resample/},
+}
+
+@misc{permute2021,
+  author = {Jarrod Millman},
+  title = {permute 0.2},
+  year  = {2021},
+  month = {06},
+  url   = {https://github.com/statlab/permute},
+}

--- a/paper.md
+++ b/paper.md
@@ -35,7 +35,7 @@ This is an early example of a *permutation test*. Like *Monte Carlo tests* [@rob
 
 Scientists and engineers frequently analyze data by considering questions of the following forms.
 
-1. Are the observations sampled from a hypothesized distribution? For instance, in Darwin's experiment, are the differences in heights between paired plants normally distributed?
+1. Are the observations sampled from a hypothesized distribution? For instance, in Darwin's experiment [@darwin1877effects], are the differences in heights between paired plants normally distributed?
 2. Are the samples drawn from the *same* distribution? For example, does the fertilization method have no effect on plant height?
 3. What can be inferred from the samples about the true value of a population statistic? For instance, what is the uncertainty in the true mean difference in heights between paired plants?
 
@@ -43,7 +43,7 @@ Monte Carlo hypothesis tests, permutation tests, and the bootstrap are general p
 
 Although there are a variety of specialized statistical procedures for answering such questions (e.g., normality tests, t-tests, standard error of the mean), most computer implementations provide answers that are only guaranteed to be accurate when assumptions that simplify the mathematics are met (e.g., the sample size is large, there are no ties in the data). At the expense of additional computation, the `scipy.stats` functions `monte_carlo_test`, `permutation_test`, and `bootstrap` provide accurate answers to questions 1-3 even when the simplifying assumptions of specialized procedures are not met. Furthermore, these functions can be used to answer questions 1-3 even when specialized procedures have not been *developed*, giving users tremendous flexibility in the analysis that they can perform.
 
-Before the release of SciPy 1.9.0, the need for these procedures was partially met in the scientific Python ecosystem by tutorials (e.g., blog posts, medium.com) and niche packages, but the functions in SciPy have several advantages:
+Before the release of SciPy 1.9.0, the need for these procedures was partially met in the scientific Python ecosystem by tutorials (e.g., [@ye2020; @saenger2019; @omar2021]) and niche packages (e.g., [@resample2020; @permute2021]), but the functions in SciPy have several advantages:
 
 - Prevalence: SciPy is one of the most frequently downloaded scientific Python packages. If a Python user finds the need for these statistical methods, chances are that they already have SciPy, eliminating the need to find and install a new package.
 - Speed: the functions take advantage of vectorized user code, avoiding slow Python loops.

--- a/paper.md
+++ b/paper.md
@@ -33,9 +33,9 @@ This is an early example of a *permutation test*. Like *Monte Carlo tests* [@rob
 
 # Statement of need
 
-Scientists and engineers frequently analyze data by considering questions of the following forms.
+Scientists and engineers frequently analyze data by considering questions of the following forms, illustrated with examples based on Darwin's experiment [@darwin1877effects].
 
-1. Are the observations sampled from a hypothesized distribution? For instance, in Darwin's experiment [@darwin1877effects], are the differences in heights between paired plants normally distributed?
+1. Are the observations sampled from a hypothesized distribution? For instance, are the differences in heights between paired plants normally distributed?
 2. Are the samples drawn from the *same* distribution? For example, does the fertilization method have no effect on plant height?
 3. What can be inferred from the samples about the true value of a population statistic? For instance, what is the uncertainty in the true mean difference in heights between paired plants?
 


### PR DESCRIPTION
#### Reference issue
https://github.com/openjournals/joss-reviews/issues/5092#issuecomment-1504807777

#### What does this implement/fix?
@SaranjeetKaur suggested:

> @mdhaber - it might be helpful to add link to the references in the section "Statement of need" (that is, for all the 3 questions, when you are sharing examples which were introduced in the Summary)

> Also when you are describing the state of the ecosystem before the release of SciPy 1.9.0 and how it was partially met by tutorials, blog posts, medium.com, and niche packages - share some references here too, if possible.

This PR attempts to address these comments.
