### PR TITLE
DEP: scipy.stats.morestats: improve deprecation warnings 

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -33,8 +33,9 @@ def __dir__():
 def __getattr__(name):
     if name not in __all__:
         raise AttributeError(
-            "`scipy.stats.morestats` is deprecated and has no attribute "
-            f"`{name}`.")
+            f"`scipy.stats.morestats` has no attribute `{name}`; furthermore, "
+            "`scipy.stats.morestats` is deprecated and will be removed in "
+            "SciPy 2.0.0.")
 
     attr = getattr(scipy.stats, name, None)
 
@@ -44,8 +45,9 @@ def __getattr__(name):
                    "will be removed in SciPy 2.0.0.")
     else:
         message = (f"`scipy.stats.morestats.{name}` is deprecated along with "
-                   "the `scipy.stats.morestats` namespace and will be removed "
-                   "in SciPy 1.13.")
+                   "the `scipy.stats.morestats` namespace. "
+                   f"`scipy.stats.morestats.{name}` will be removed in SciPy 1.13.0, and "
+                   "the `scipy.stats.morestats` namespace will be removed in SciPy 2.0.0.")
 
     warnings.warn(message, category=DeprecationWarning, stacklevel=2)
 

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -14,29 +14,36 @@ __all__ = [  # noqa: F822
     'fligner', 'mood', 'wilcoxon', 'median_test',
     'circmean', 'circvar', 'circstd', 'anderson_ksamp',
     'yeojohnson_llf', 'yeojohnson', 'yeojohnson_normmax',
-    'yeojohnson_normplot', 'annotations', 'namedtuple', 'isscalar', 'log',
-    'around', 'unique', 'arange', 'sort', 'amin', 'amax', 'atleast_1d',
-    'array', 'compress', 'exp', 'ravel', 'count_nonzero', 'arctan2',
-    'hypot', 'optimize', 'find_repeats',
-    'chi2_contingency', 'distributions', 'rv_generic', 'Mean',
-    'Variance', 'Std_dev', 'ShapiroResult', 'AndersonResult',
-    'Anderson_ksampResult', 'AnsariResult', 'BartlettResult',
-    'LeveneResult', 'FlignerResult', 'WilcoxonResult'
+    'yeojohnson_normplot', 'find_repeats',
+    'chi2_contingency', 'distributions'
 ]
 
+_deprecated = {'annotations', 'namedtuple', 'isscalar', 'log', 'around',
+               'unique', 'arange', 'sort', 'amin', 'amax', 'atleast_1d',
+               'array', 'compress', 'exp', 'ravel', 'count_nonzero', 'arctan2',
+               'hypot', 'optimize', 'Mean', 'Variance', 'Std_dev',
+               'ShapiroResult', 'AndersonResult', 'Anderson_ksampResult',
+               'AnsariResult', 'BartlettResult', 'LeveneResult',
+               'FlignerResult', 'WilcoxonResult', 'rv_generic'}
 
 def __dir__():
     return __all__
 
 
 def __getattr__(name):
-    if name not in __all__:
+    if name not in __all__ and name not in _deprecated:
         raise AttributeError(
-            "scipy.stats.morestats is deprecated and has no attribute "
-            f"{name}. Try looking in scipy.stats instead.")
+            "`scipy.stats.morestats` is deprecated and has no attribute "
+            f"`{name}`.")
 
-    warnings.warn(f"Please use `{name}` from the `scipy.stats` namespace, "
-                  "the `scipy.stats.morestats` namespace is deprecated.",
-                  category=DeprecationWarning, stacklevel=2)
+    if name in __all__:
+        message = (f"Please import `{name}` from the `scipy.stats` namespace; "
+                   "the `scipy.stats.morestats` namespace is deprecated.")
+    else:
+        message = (f"`scipy.stats.morestats.{name}` is deprecated along with "
+                   "the `scipy.stats.morestats` namespace and will be removed "
+                   "in SciPy 1.13.")
+
+    warnings.warn(message, category=DeprecationWarning, stacklevel=2)
 
     return getattr(_morestats, name)

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -2,6 +2,7 @@
 # Use the `scipy.stats` namespace for importing the functions
 # included below.
 
+import scipy
 import warnings
 from . import _morestats
 
@@ -14,31 +15,33 @@ __all__ = [  # noqa: F822
     'fligner', 'mood', 'wilcoxon', 'median_test',
     'circmean', 'circvar', 'circstd', 'anderson_ksamp',
     'yeojohnson_llf', 'yeojohnson', 'yeojohnson_normmax',
-    'yeojohnson_normplot', 'find_repeats',
-    'chi2_contingency', 'distributions'
+    'yeojohnson_normplot', 'annotations', 'namedtuple', 'isscalar', 'log',
+    'around', 'unique', 'arange', 'sort', 'amin', 'amax', 'atleast_1d',
+    'array', 'compress', 'exp', 'ravel', 'count_nonzero', 'arctan2',
+    'hypot', 'optimize', 'find_repeats',
+    'chi2_contingency', 'distributions', 'rv_generic', 'Mean',
+    'Variance', 'Std_dev', 'ShapiroResult', 'AndersonResult',
+    'Anderson_ksampResult', 'AnsariResult', 'BartlettResult',
+    'LeveneResult', 'FlignerResult', 'WilcoxonResult'
 ]
 
-_deprecated = {'annotations', 'namedtuple', 'isscalar', 'log', 'around',
-               'unique', 'arange', 'sort', 'amin', 'amax', 'atleast_1d',
-               'array', 'compress', 'exp', 'ravel', 'count_nonzero', 'arctan2',
-               'hypot', 'optimize', 'Mean', 'Variance', 'Std_dev',
-               'ShapiroResult', 'AndersonResult', 'Anderson_ksampResult',
-               'AnsariResult', 'BartlettResult', 'LeveneResult',
-               'FlignerResult', 'WilcoxonResult', 'rv_generic'}
 
 def __dir__():
     return __all__
 
 
 def __getattr__(name):
-    if name not in __all__ and name not in _deprecated:
+    if name not in __all__:
         raise AttributeError(
             "`scipy.stats.morestats` is deprecated and has no attribute "
             f"`{name}`.")
 
-    if name in __all__:
+    attr = getattr(scipy.stats, name, None)
+
+    if attr is not None:
         message = (f"Please import `{name}` from the `scipy.stats` namespace; "
-                   "the `scipy.stats.morestats` namespace is deprecated.")
+                   "the `scipy.stats.morestats` namespace is deprecated and "
+                   "will be removed in SciPy 2.0.0.")
     else:
         message = (f"`scipy.stats.morestats.{name}` is deprecated along with "
                    "the `scipy.stats.morestats` namespace and will be removed "

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2803,3 +2803,36 @@ class TestFDRControl:
         assert_array_equal(stats.false_discovery_control([0.25]), [0.25])
         assert_array_equal(stats.false_discovery_control(0.25), 0.25)
         assert_array_equal(stats.false_discovery_control([]), [])
+
+
+def test_morestats_deprecation():
+    # gh-18279 noted that deprecation warnings for imports from private modules
+    # were misleading. Check that this is resolved.
+    import scipy.stats.morestats as module
+
+    # Attributes that were formerly in `morestats` can still be imported from
+    # `morestats`, albeit with a deprecation warning. The specific message
+    # depends on whether the attribute is public in `scipy.stats` or not.
+
+    for attr_name in module._deprecated:
+        message = f"`scipy.stats.morestats.{attr_name}` is deprecated..."
+        with pytest.warns(DeprecationWarning, match=message):
+            getattr(module, attr_name)
+        # Just checking that the `_deprecated` list is correct - that the
+        # deprecated attribute is not in `scipy.stats`. Python will produce the
+        # message it produces; no need to match it.
+        with pytest.raises(AttributeError):
+            getattr(stats, attr_name)
+
+    for attr_name in module.__all__:
+        message = f"Please import `{attr_name}` from the `scipy.stats`..."
+        with pytest.warns(DeprecationWarning, match=message):
+            getattr(module, attr_name)
+
+    # Attributes that were not in `morestats` get an error notifying the user
+    # that the attribute is not in `morestats` and that `morestats` is
+    # deprecated.
+
+    message = "`scipy.stats.morestats` is deprecated..."
+    with pytest.raises(AttributeError, match=message):
+        getattr(module, "ekki")

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2813,26 +2813,18 @@ def test_morestats_deprecation():
     # Attributes that were formerly in `morestats` can still be imported from
     # `morestats`, albeit with a deprecation warning. The specific message
     # depends on whether the attribute is public in `scipy.stats` or not.
-
-    for attr_name in module._deprecated:
-        message = f"`scipy.stats.morestats.{attr_name}` is deprecated..."
-        with pytest.warns(DeprecationWarning, match=message):
-            getattr(module, attr_name)
-        # Just checking that the `_deprecated` list is correct - that the
-        # deprecated attribute is not in `scipy.stats`. Python will produce the
-        # message it produces; no need to match it.
-        with pytest.raises(AttributeError):
-            getattr(stats, attr_name)
-
     for attr_name in module.__all__:
-        message = f"Please import `{attr_name}` from the `scipy.stats`..."
+        attr = getattr(stats, attr_name, None)
+        if attr is None:
+            message = f"`scipy.stats.morestats.{attr_name}` is deprecated..."
+        else:
+            message = f"Please import `{attr_name}` from the `scipy.stats`..."
         with pytest.warns(DeprecationWarning, match=message):
             getattr(module, attr_name)
 
     # Attributes that were not in `morestats` get an error notifying the user
     # that the attribute is not in `morestats` and that `morestats` is
     # deprecated.
-
     message = "`scipy.stats.morestats` is deprecated..."
     with pytest.raises(AttributeError, match=message):
         getattr(module, "ekki")


### PR DESCRIPTION
#### Reference issue
Begins to address gh-18279

#### What does this implement/fix?
@tupui Thought I'd get your opinion here before opening on the main repo.

This addresses gh-18279 by emitting the right error or warning depending on what attribute is being accessed/imported.