### PR TITLE
ENH: stats.ansari: add axis / nan_policy / keepdims support

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2583,6 +2583,7 @@ class _ABW:
 _abw_state = _ABW()
 
 
+@_axis_nan_policy_factory(AnsariResult, n_samples=2)
 def ansari(x, y, alternative='two-sided'):
     """Perform the Ansari-Bradley test for equal scale parameters.
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -64,7 +64,8 @@ axis_nan_policy_cases = [
     (_get_ttest_ci(stats.ttest_ind), tuple(), dict(), 2, 2, False, None),
     (stats.mode, tuple(), dict(), 1, 2, True, lambda x: (x.mode, x.count)),
     (stats.differential_entropy, tuple(), dict(), 1, 1, False, lambda x: (x,)),
-    (stats.variation, tuple(), dict(), 1, 1, False, lambda x: (x,))
+    (stats.variation, tuple(), dict(), 1, 1, False, lambda x: (x,)),
+    (stats.ansari, tuple(), {}, 2, 2, False, None),
 ]
 
 # If the message is one of those expected, put nans in


### PR DESCRIPTION
@tirthasheshpatel Shall I also submit a PRs that you can review, about one per week, or is that too much?

I'll wait for SciPy's CI to get fixed before opening this one on the main repo.

I think it's really as simple as this. The one thing I noticed is that currently, for Nd input, `ansari` returns a scalar result. However, the result seems to be garbage - it's different from `axis=None` / raveling the arrays before passing them to the function. So I think it's safe to let `axis=0` be the default since there's no useful behavior to maintain.