### PR TITLE
add rng to rand and random. add test of use of rng

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1244,15 +1244,16 @@ def _random(shape, density=0.01, format=None, dtype=None,
     return vals, ind
 
 
+@_transition_to_rng("random_state")
 def random(m, n, density=0.01, format='coo', dtype=None,
-           random_state=None, data_rvs=None):
+           rng=None, data_rvs=None):
     """Generate a sparse matrix of the given shape and density with randomly
     distributed values.
 
     .. warning::
 
         Since numpy 1.17, passing a ``np.random.Generator`` (e.g.
-        ``np.random.default_rng``) for ``random_state`` will lead to much
+        ``np.random.default_rng``) for ``rng`` will lead to much
         faster execution times.
 
         A much slower implementation is used by default for backwards
@@ -1275,15 +1276,11 @@ def random(m, n, density=0.01, format='coo', dtype=None,
         sparse matrix format.
     dtype : dtype, optional
         type of the returned matrix values.
-    random_state : {None, int, `numpy.random.Generator`,
-                    `numpy.random.RandomState`}, optional
-
-        - If `seed` is None (or `np.random`), the `numpy.random.RandomState`
-          singleton is used.
-        - If `seed` is an int, a new ``RandomState`` instance is used,
-          seeded with `seed`.
-        - If `seed` is already a ``Generator`` or ``RandomState`` instance then
-          that instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
 
         This random state will be used for sampling the sparsity structure, but
         not necessarily for sampling the values of the structurally nonzero
@@ -1313,12 +1310,12 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     >>> import scipy as sp
     >>> import numpy as np
     >>> rng = np.random.default_rng()
-    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng)
+    >>> S = sp.sparse.random(3, 4, density=0.25, rng=rng)
 
     Providing a sampler for the values:
 
     >>> rvs = sp.stats.poisson(25, loc=10).rvs
-    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng, data_rvs=rvs)
+    >>> S = sp.sparse.random(3, 4, density=0.25, rng=rng, data_rvs=rvs)
     >>> S.toarray()
     array([[ 36.,   0.,  33.,   0.],   # random
            [  0.,   0.,   0.,   0.],
@@ -1327,27 +1324,27 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     Building a custom distribution.
     This example builds a squared normal from np.random:
 
-    >>> def np_normal_squared(size=None, random_state=rng):
-    ...     return random_state.standard_normal(size) ** 2
-    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng,
+    >>> def np_normal_squared(size=None, rng=rng):
+    ...     return rng.standard_normal(size) ** 2
+    >>> S = sp.sparse.random(3, 4, density=0.25, rng=rng,
     ...                      data_rvs=np_normal_squared)
 
     Or we can build it from sp.stats style rvs functions:
 
-    >>> def sp_stats_normal_squared(size=None, random_state=rng):
+    >>> def sp_stats_normal_squared(size=None, rng=rng):
     ...     std_normal = sp.stats.distributions.norm_gen().rvs
-    ...     return std_normal(size=size, random_state=random_state) ** 2
-    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng,
+    ...     return std_normal(size=size, random_state=rng) ** 2
+    >>> S = sp.sparse.random(3, 4, density=0.25, rng=rng,
     ...                      data_rvs=sp_stats_normal_squared)
 
     Or we can subclass sp.stats rv_continuous or rv_discrete:
 
     >>> class NormalSquared(sp.stats.rv_continuous):
     ...     def _rvs(self,  size=None, random_state=rng):
-    ...         return random_state.standard_normal(size) ** 2
+    ...         return rng.standard_normal(size) ** 2
     >>> X = NormalSquared()
     >>> Y = X()  # get a frozen version of the distribution
-    >>> S = sp.sparse.random(3, 4, density=0.25, random_state=rng, data_rvs=Y.rvs)
+    >>> S = sp.sparse.random(3, 4, density=0.25, rng=rng, data_rvs=Y.rvs)
     """
     if n is None:
         n = m
@@ -1358,11 +1355,12 @@ def random(m, n, density=0.01, format='coo', dtype=None,
             return data_rvs(size)
     else:
         data_rvs_kw = None
-    vals, ind = _random((m, n), density, format, dtype, random_state, data_rvs_kw)
+    vals, ind = _random((m, n), density, format, dtype, rng, data_rvs_kw)
     return coo_matrix((vals, ind), shape=(m, n)).asformat(format)
 
 
-def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):
+@_transition_to_rng("random_state")
+def rand(m, n, density=0.01, format="coo", dtype=None, rng=None):
     """Generate a sparse matrix of the given shape and density with uniformly
     distributed values.
 
@@ -1383,15 +1381,11 @@ def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):
         sparse matrix format.
     dtype : dtype, optional
         type of the returned matrix values.
-    random_state : {None, int, `numpy.random.Generator`,
-                    `numpy.random.RandomState`}, optional
-
-        If `seed` is None (or `np.random`), the `numpy.random.RandomState`
-        singleton is used.
-        If `seed` is an int, a new ``RandomState`` instance is used,
-        seeded with `seed`.
-        If `seed` is already a ``Generator`` or ``RandomState`` instance then
-        that instance is used.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
 
     Returns
     -------
@@ -1409,7 +1403,7 @@ def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):
     Examples
     --------
     >>> from scipy.sparse import rand
-    >>> matrix = rand(3, 4, density=0.25, format="csr", random_state=42)
+    >>> matrix = rand(3, 4, density=0.25, format="csr", rng=42)
     >>> matrix
     <Compressed Sparse Row sparse matrix of dtype 'float64'
         with 3 stored elements and shape (3, 4)>
@@ -1419,4 +1413,4 @@ def rand(m, n, density=0.01, format="coo", dtype=None, random_state=None):
            [0.        , 0.        , 0.        , 0.        ]])
 
     """
-    return random(m, n, density, format, dtype, random_state)
+    return random(m, n, density, format, dtype, rng)

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1244,7 +1244,7 @@ def _random(shape, density=0.01, format=None, dtype=None,
     return vals, ind
 
 
-@_transition_to_rng("random_state")
+@_transition_to_rng("random_state", position_num=5)
 def random(m, n, density=0.01, format='coo', dtype=None,
            rng=None, data_rvs=None):
     """Generate a sparse matrix of the given shape and density with randomly
@@ -1359,7 +1359,7 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     return coo_matrix((vals, ind), shape=(m, n)).asformat(format)
 
 
-@_transition_to_rng("random_state")
+@_transition_to_rng("random_state", position_num=5)
 def rand(m, n, density=0.01, format="coo", dtype=None, rng=None):
     """Generate a sparse matrix of the given shape and density with uniformly
     distributed values.

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -7,7 +7,7 @@ from numpy.testing import (assert_equal, assert_,
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._testutils import check_free_memory
-from scipy._lib._util import check_random_state, _transition_to_rng
+from scipy._lib._util import check_random_state
 
 from scipy.sparse import (csr_matrix, coo_matrix,
                           csr_array, coo_array,
@@ -37,6 +37,7 @@ def _sprandn(m, n, density=0.01, format="coo", dtype=None,
                                 rng=rng, data_rvs=data_rvs)
     return construct.random(m, n, density, format, dtype,
                             random_state=rng, data_rvs=data_rvs)
+
 
 def _sprandn_array(m, n, density=0.01, format="coo", dtype=None,
                    rng=None, random_state=None):

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -785,14 +785,15 @@ class TestConstructUtils:
         construct.random_array((10, 10, 10, 10, 10), dtype='d')
 
     def test_random_array_maintains_array_shape(self):
-        arr = construct.random_array((0, 4), density=0.3, dtype=int, rng=0)
+        # preserve use of old random_state during SPEC 7 transition
+        arr = construct.random_array((0, 4), density=0.3, dtype=int, random_state=0)
         assert arr.shape == (0, 4)
 
         arr = construct.random_array((10, 10, 10), density=0.3, dtype=int, rng=0)
         assert arr.shape == (10, 10, 10)
 
-        A = construct.random_array((10, 10, 10, 10, 10), density=0.3, dtype=int, rng=0)
-        assert A.shape == (10, 10, 10, 10, 10)
+        arr = construct.random_array((10, 10, 10, 10, 10), density=0.3, dtype=int, rng=0)
+        assert arr.shape == (10, 10, 10, 10, 10)
 
     def test_random_sparse_matrix_returns_correct_number_of_non_zero_elements(self):
         # A 10 x 10 matrix, with density of 12.65%, should have 13 nonzero elements.

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -7,7 +7,7 @@ from numpy.testing import (assert_equal, assert_,
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._testutils import check_free_memory
-from scipy._lib._util import check_random_state
+from scipy._lib._util import check_random_state, _transition_to_rng
 
 from scipy.sparse import (csr_matrix, coo_matrix,
                           csr_array, coo_array,
@@ -24,20 +24,33 @@ sparse_formats = ['csr','csc','coo','bsr','dia','lil','dok']
 #TODO check whether format=XXX is respected
 
 
-def _sprandn(m, n, density=0.01, format="coo", dtype=None, random_state=None):
+def _sprandn(m, n, density=0.01, format="coo", dtype=None,
+             rng=None, random_state=None):
     # Helper function for testing.
-    random_state = check_random_state(random_state)
-    data_rvs = random_state.standard_normal
+    if random_state is not None:
+        rng = check_random_state(random_state)
+    else:
+        rng = np.random.default_rng(rng)
+    data_rvs = rng.standard_normal
+    if random_state is None:
+        return construct.random(m, n, density, format, dtype,
+                                rng=rng, data_rvs=data_rvs)
     return construct.random(m, n, density, format, dtype,
-                            random_state, data_rvs)
+                            random_state=rng, data_rvs=data_rvs)
 
-
-def _sprandn_array(m, n, density=0.01, format="coo", dtype=None, rng=None):
+def _sprandn_array(m, n, density=0.01, format="coo", dtype=None,
+                   rng=None, random_state=None):
     # Helper function for testing.
-    rng = np.random.default_rng(rng)
+    if random_state is not None:
+        rng = check_random_state(random_state)
+    else:
+        rng = np.random.default_rng(rng)
     data_sampler = rng.standard_normal
+    if random_state is None:
+        return construct.random_array((m, n), density=density, format=format,
+                                      dtype=dtype, rng=rng, data_sampler=data_sampler)
     return construct.random_array((m, n), density=density, format=format, dtype=dtype,
-                                  rng=rng, data_sampler=data_sampler)
+                                  random_state=rng, data_sampler=data_sampler)
 
 
 class TestConstructUtils:
@@ -697,7 +710,6 @@ class TestConstructUtils:
         assert_array_equal(construct.block_diag([A, B]).toarray(),
                            [[1, 0, 3, 0, 0], [0, 0, 0, 0, 4]])
 
-
     def test_block_diag_1(self):
         """ block_diag with one matrix """
         assert_equal(construct.block_diag([[1, 0]]).toarray(),
@@ -740,11 +752,10 @@ class TestConstructUtils:
                 assert_equal(x.shape, (5, 10))
                 assert_equal(x.nnz, 5)
 
-            x1 = f(5, 10, density=0.1, random_state=4321)
+            x1 = f(5, 10, density=0.1, rng=4321)
             assert_equal(x1.dtype, np.float64)
 
-            x2 = f(5, 10, density=0.1,
-                   random_state=np.random.RandomState(4321))
+            x2 = f(5, 10, density=0.1, rng=np.random.default_rng(4321))
 
             assert_array_equal(x1.data, x2.data)
             assert_array_equal(x1.row, x2.row)
@@ -761,20 +772,21 @@ class TestConstructUtils:
             assert_raises(ValueError, lambda: f(5, 10, 1.1))
             assert_raises(ValueError, lambda: f(5, 10, -0.1))
 
-    def test_rand(self):
+    @pytest.mark.parametrize("rng", [None, 4321, np.random.RandomState(4321),
+                                     np.random.default_rng(4321)])
+    def test_rand(self, rng):
         # Simple distributional checks for sparse.rand.
-        random_states = [None, 4321, np.random.RandomState()]
-        try:
-            gen = np.random.default_rng()
-            random_states.append(gen)
-        except AttributeError:
-            pass
+        x = sprand(10, 20, density=0.5, dtype=np.float64, random_state=rng)
+        assert_(np.all(np.less_equal(0, x.data)))
+        assert_(np.all(np.less_equal(x.data, 1)))
 
-        for random_state in random_states:
-            x = sprand(10, 20, density=0.5, dtype=np.float64,
-                       random_state=random_state)
+        if not isinstance(rng, np.random.RandomState):  # not accepted by `rng`
+            x = sprand(10, 20, density=0.5, dtype=np.float64, rng=rng)
             assert_(np.all(np.less_equal(0, x.data)))
             assert_(np.all(np.less_equal(x.data, 1)))
+        else:
+            with assert_raises(TypeError, match="SeedSequence expects int"):
+                sprand(10, 20, density=0.5, dtype=np.float64, rng=rng)
 
     @pytest.mark.parametrize("rng", [None, 4321, np.random.RandomState(4321),
                                      np.random.default_rng(4321)])
@@ -785,13 +797,48 @@ class TestConstructUtils:
         x = _sprandn(10, 20, density=0.5, dtype=np.float64, random_state=rng)
         assert_(np.any(np.less(x.data, 0)))
         assert_(np.any(np.less(1, x.data)))
-
-        if isinstance(rng, np.random.RandomState):  # not accepted by `rng`
-            return
-
-        x = _sprandn_array(10, 20, density=0.5, dtype=np.float64, rng=rng)
+        x = _sprandn_array(10, 20, density=0.5, dtype=np.float64, random_state=rng)
         assert_(np.any(np.less(x.data, 0)))
         assert_(np.any(np.less(1, x.data)))
+
+        if isinstance(rng, np.random.RandomState):  # not accepted by `rng`
+            with assert_raises(TypeError, match="SeedSequence expects int"):
+                _sprandn(10, 20, density=0.5, dtype=np.float64, rng=rng)
+            with assert_raises(TypeError, match="SeedSequence expects int"):
+                _sprandn_array(10, 20, density=0.5, dtype=np.float64, rng=rng)
+        else:
+            x = _sprandn(10, 20, density=0.5, dtype=np.float64, rng=rng)
+            assert_(np.any(np.less(x.data, 0)))
+            assert_(np.any(np.less(1, x.data)))
+            x = _sprandn_array(10, 20, density=0.5, dtype=np.float64, rng=rng)
+            assert_(np.any(np.less(x.data, 0)))
+            assert_(np.any(np.less(1, x.data)))
+
+    @pytest.mark.parametrize(
+        "func", [construct.rand, construct.random, construct.random_array]
+    )
+    def test_random_state_during_SPEC_7_transition(self, func):
+        # preserve use of old random_state during SPEC 7 transition
+        default_rng = np.random.default_rng
+        RandomState = np.random.RandomState
+        shape = ((5, 10),) if func is construct.random_array else (5, 10)
+
+        x1 = func(*shape, density=0.1, random_state=4321)
+        x2 = func(*shape, density=0.1, random_state=RandomState(4321))
+        x3 = func(*shape, density=0.1, random_state=default_rng(4321))
+        x4 = func(*shape, density=0.1, rng=4321)
+        x5 = func(*shape, density=0.1, rng=default_rng(4321))
+        with assert_raises(TypeError, match="SeedSequence expects int"):
+            func(*shape, density=0.1, rng=RandomState(4321))
+
+        assert_equal(x1.data, x2.data)
+        assert_equal(x1.coords, x2.coords)
+        assert_equal(x3.data, x4.data)
+        assert_equal(x3.coords, x4.coords)
+        assert_equal(x3.data, x5.data)
+        assert_equal(x3.coords, x5.coords)
+        # assert_not_equal
+        assert_raises(AssertionError, assert_equal, x1.coords, x4.coords)
 
     def test_random_accept_str_dtype(self):
         # anything that np.dtype can convert to a dtype should be accepted
@@ -802,16 +849,14 @@ class TestConstructUtils:
         construct.random_array((10, 10, 10, 10, 10), dtype='d')
 
     def test_random_array_maintains_array_shape(self):
-        # preserve use of old random_state during SPEC 7 transition
-        arr = construct.random_array((0, 4), density=0.3, dtype=int, random_state=0)
+        arr = construct.random_array((0, 4), density=0.3, dtype=int)
         assert arr.shape == (0, 4)
 
-        arr = construct.random_array((10, 10, 10), density=0.3, dtype=int, rng=0)
+        arr = construct.random_array((10, 10, 10), density=0.3, dtype=int)
         assert arr.shape == (10, 10, 10)
 
         arr = construct.random_array((10, 10, 10, 10, 10), density=0.3, dtype=int)
         assert arr.shape == (10, 10, 10, 10, 10)
-
 
     def test_random_sparse_matrix_returns_correct_number_of_non_zero_elements(self):
         # A 10 x 10 matrix, with density of 12.65%, should have 13 nonzero elements.


### PR DESCRIPTION
- add rng to rand and random. 
- revamp sprandn/sprandn_array functions to allow testing of random_state/rng args of the underlying random_array functions. (Using the transition decorator for these functions is insufficient b/c it doesn't check the underlying functions.)
- add test to check that rng impacts the results.

