### PR TITLE
Simplify logsumexp edge case handling

### DIFF
--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -111,9 +111,9 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     if xp_size(a) != 0:
         with np.errstate(over='ignore'):
-            # Where result is infinite, we use the direct logsumexp calculation to delegate
-            # edge case handling to the behavior of `xp.log` and `xp.exp`, which should
-            # follow the C99 standard for complex values.
+            # Where result is infinite, we use the direct logsumexp calculation to
+            # delegate edge case handling to the behavior of `xp.log` and `xp.exp`,
+            # which should follow the C99 standard for complex values.
             b_exp_a = xp.exp(a) if b is None else b * xp.exp(a)
             sum = xp.sum(b_exp_a, axis=axis, keepdims=True)
             sgn_inf = _sign(sum, xp) if return_sign else None

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -195,56 +195,55 @@ def _logsumexp(a, b, axis, return_sign, xp):
     # of the exponential. Possible enhancement: include log of `b` magnitude in `a`.
     a_max, i_max = _elements_and_indices_with_max_real(a, axis=axis, xp=xp)
 
-    # for precision, these terms are separated out of the main sum.
-    a = xpx.at(a, i_max).set(-xp.inf)
+    # When a_max is finite, perform the logsumexp trick to prevent overflow/underflow
+    # If a_max is infinite, use direct logsumexp calculation to delegate edge case
+    # handling to the behavior of xp.log and xp.exp which should follow the C99 standard
+    # for complex values.
+    a_max_finite = xp.isfinite(a_max)
+    # For precision, these terms are separated out of the main sum in typical
+    # cases where the logsumexp trick is used.
+    a = xpx.at(a, xp.logical_and(a_max_finite, i_max)).set(-xp.inf)
     i_max_dt = xp.astype(i_max, a.dtype)
     # This is an inefficient way of getting `m` because it is the sum of a sparse
     # array; however, this is the simplest way I can think of to get the right shape.
     m = (xp.sum(i_max_dt, axis=axis, keepdims=True, dtype=a.dtype) if b is None
          else xp.sum(b * i_max_dt, axis=axis, keepdims=True, dtype=a.dtype))
 
+    # Shift in cases where logsumexp trick is used. This will warn on some backends
+    # for cases where a_max has non finite values since a - a_max will be computed
+    # regardless of the value of a_max_finite.
+    a = xp.where(a_max_finite, a - a_max, a)
 
-    # `a - shift` will introduce NaNs if both `a` and `shift` have infinities of the
-    # same sign.
-    # For positive infinite `shift`, `a - shift` does the right thing if all of `a` are
-    # finite. If some of `a` are imaginary with `+inf` real component, it is not a huge
-    # problem for NaNs to appear. The *best* `logsumexp` result in this case could have
-    # either `inf` or `nan` real part and finite or `nan` imaginary part, depending on
-    # the specifics. The logic for this is not implemented, and previous implementations
-    # of `logsumexp` have returned garbage phase for multiple complex infinities, so
-    # returning `nan + nan*j` is an improvement over a result with incorrect phase.
-    # For negative infinities, this can only occur if *all* elements have negative
-    # infinite real part, so the result is the logarithm of `0`, and the phase is
-    # meaningless. The value returned by `logsumexp` will have the same phase as
-    # `a_max`, which should be fine, since this function has never had a principled
-    # phase convention for this case. Perhaps NaN phase would be best, but we save
-    # that for another day.
-    shift = xp.where(xp.logical_or(xp.isfinite(a_max), xp_real(a_max) > 0),
-                     a_max, 0.)
+    # Exponentiate
+    exp = xp.exp(a)
+    exp = b * exp if b is not None else exp
 
-    # Shift, exponentiate, scale, and sum
-    exp = b * xp.exp(a - shift) if b is not None else xp.exp(a - shift)
+    # Sum
     s = xp.sum(exp, axis=axis, keepdims=True, dtype=exp.dtype)
-    s = xp.where(s == 0, s, s/m)
+
+    # Scale in cases where logsumexp trick is used.
+    s = xp.where((s != 0) & a_max_finite, s / m, s)
 
     # Separate sign/magnitude information
     sgn = None
     if return_sign:
         # Use the numpy>=2.0 convention for sign.
         # When all array libraries agree, this can become sng = xp.sign(s).
-        sgn = _sign(s + 1, xp=xp) * _sign(m, xp=xp)
+        sgn = xp.where(a_max_finite,
+                       _sign(s + 1, xp=xp) * _sign(m, xp=xp),
+                       _sign(s, xp=xp))
 
         if xp.isdtype(s.dtype, "real floating"):
             # The log functions need positive arguments
-            s = xp.where(s < -1, -s - 2, s)
+            s = xp.where(xp.logical_and(s < -1, a_max_finite), -s - 2, s)
+            s = xp.where(~a_max_finite, xp.abs(s), s)
             m = xp.abs(m)
         else:
             # `a_max` can have a sign component for complex input
-            sgn = sgn * xp.exp(xp.imag(a_max) * 1.0j)
+            sgn = xp.where(a_max_finite, sgn * xp.exp(xp.imag(a_max) * 1.0j), sgn)
 
-    # Take log and undo shift
-    out = xp.log1p(s) + xp.log(m) + a_max
-
+    # Take log. Undo shift in cases where logsumexp trick is used.
+    out = xp.where(a_max_finite, xp.log1p(s) + xp.log(m) + a_max, xp.log(s))
     out = xp.real(out) if return_sign else out
 
     return out, sgn

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -4,8 +4,7 @@ import pytest
 
 import numpy as np
 
-from scipy._lib._array_api import (is_array_api_strict, xp_default_dtype,
-                                   is_numpy)
+from scipy._lib._array_api import is_array_api_strict, xp_default_dtype
 from scipy._lib._array_api_no_0d import (xp_assert_equal, xp_assert_close,
                                          xp_assert_less)
 

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -1,3 +1,4 @@
+import itertools as it
 import math
 import pytest
 
@@ -266,18 +267,35 @@ class TestLogSumExp:
         xp_assert_close(xp.real(res), xp.real(ref))
         xp_assert_close(xp.imag(res), xp.imag(ref), atol=0, rtol=1e-15)
 
-    @pytest.mark.parametrize('x', [
-        [-np.inf, -np.inf],
-        [np.inf, np.inf],
-        [-np.inf + 0j, -np.inf + 0.7533j],
-        [np.inf + 1j, -0.9116 + 0.7533j],
-        [np.inf + 1.0000j, np.inf + 0.7533j],
-    ])
-    def test_gh22601_infinite_elements(self, x, xp):
+
+    @pytest.mark.parametrize('x,y', it.product(
+        [
+            -np.inf,
+            np.inf,
+            complex(-np.inf, 0.),
+            complex(-np.inf, -0.),
+            complex(-np.inf, np.inf),
+            complex(-np.inf, -np.inf),
+            complex(np.inf, 0.),
+            complex(np.inf, -0.),
+            complex(np.inf, np.inf),
+            complex(np.inf, -np.inf),
+            # Phase in each quadrant.
+            complex(-np.inf, 0.7533),
+            complex(-np.inf, 2.3562),
+            complex(-np.inf, 3.9270),
+            complex(-np.inf, 5.4978),
+            complex(np.inf, 0.7533),
+            complex(np.inf, 2.3562),
+            complex(np.inf, 3.9270),
+            complex(np.inf, 5.4978),
+        ], repeat=2)
+    )
+    def test_gh22601_infinite_elements(self, x, y, xp):
         # Test that `logsumexp` does reasonable things in the presence of
         # real and complex infinities.
-        res = logsumexp(xp.asarray(x))
-        ref = xp.log(xp.sum(xp.exp(xp.asarray(x))))
+        res = logsumexp(xp.asarray([x, y]))
+        ref = xp.log(xp.sum(xp.exp(xp.asarray([x, y]))))
         xp_assert_equal(res, ref)
 
 

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -41,6 +41,7 @@ def test_wrap_radians(xp):
 # library)
 @pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning")
 @pytest.mark.filterwarnings("ignore:divide by zero encountered:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:overflow encountered:RuntimeWarning")
 class TestLogSumExp:
     def test_logsumexp(self, xp):
         # Test with zero-size array


### PR DESCRIPTION
@steppi since the code in `_logsumexp` had enough mathematical complexity, I've tried to keep it relatively free of additional complexity of special cases. How about putting the edge case handling in the public `logsumexp` like this? I see that it's hard to use `apply_where`, but `where` works, and if we need to recover performance, we can do this only for complex dtype and/or try `apply_where` again in the future.