### PR TITLE
Discrete distribution suggestion cleanup

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3656,52 +3656,25 @@ class DiscreteDistribution(UnivariateDistribution):
     def _logccdf_quadrature(self, x, **params):
         return super()._logccdf_quadrature(np.floor(x + 1), **params)
 
-    def _cdf2_quadrature(self, x, y, **params):
-        return super()._cdf2_quadrature(np.ceil(x), np.floor(y), **params)
+    def _cdf2(self, x, y, *, method):
+        raise NotImplementedError(
+            "Two argument cdf functions are currently only supported for "
+            "continuous distributions.")
 
-    def _logcdf2_quadrature(self, x, y, **params):
-        return super()._logcdf2_quadrature(np.ceil(x), np.floor(y), **params)
+    def _ccdf2(self, x, y, *, method):
+        raise NotImplementedError(
+            "Two argument cdf functions are currently only supported for "
+            "continuous distributions.")
 
-    def _cdf2_subtraction_base(self, x, y, func, **params):
-        x_, y_ = np.floor(x), np.floor(y)
-        cdf_ymx = func(x_, y_, **params)
-        pmf_x = np.where(x_ == x, self._pmf_dispatch(x_, **params), 0)
-        return cdf_ymx + pmf_x
+    def _logcdf2(self, x, y, *, method):
+        raise NotImplementedError(
+            "Two argument cdf functions are currently only supported for "
+            "continuous distributions.")
 
-    def _logcdf2_subtraction_base(self, x, y, func, **params):
-        x_, y_ = np.floor(x), np.floor(y)
-        logcdf_ymx = func(x_, y_, **params)
-        logpmf_x = np.where(x_ == x, self._logpmf_dispatch(x_, **params), -np.inf)
-        return special.logsumexp([logcdf_ymx, logpmf_x], axis=0)
-
-    def _cdf2_subtraction(self, x, y, **params):
-        return self._cdf2_subtraction_base(x, y, super()._cdf2_subtraction, **params)
-
-    def _cdf2_subtraction_safe(self, x, y, **params):
-        return self._cdf2_subtraction_base(x, y, super()._cdf2_subtraction_safe,
-                                           **params)
-
-    def _logcdf2_subtraction(self, x, y, **params):
-        return self._logcdf2_subtraction_base(x, y, super()._logcdf2_subtraction,
-                                              **params)
-
-    def _logcdf2_subtraction_safe(self, x, y, **params):
-        return self._logcdf2_subtraction_base(x, y, super()._logcdf2_subtraction,
-                                              **params)
-
-    def _ccdf2_addition(self, x, y, **params):
-        a, _ = self._support(**params)
-        ccdf_y = self._ccdf_dispatch(y, **params)
-        _cdf, args = _kwargs2args(self._cdf_dispatch, kwargs=params)
-        cdf_xm1 = apply_where(x - 1 >= a, (x - 1,) + args, _cdf, fill_value=0)
-        return ccdf_y + cdf_xm1
-
-    def _logccdf2_addition(self, x, y, **params):
-        a, _ = self._support(**params)
-        logccdf_y = self._logccdf_dispatch(y, **params)
-        _logcdf, args = _kwargs2args(self._logcdf_dispatch, kwargs=params)
-        logcdf_xm1 = apply_where(x - 1 >= a, (x - 1,) + args, _logcdf, fill_value=-np.inf)
-        return special.logsumexp([logccdf_y, logcdf_xm1], axis=0)
+    def _logccdf2(self, x, y, *, method):
+        raise NotImplementedError(
+            "Two argument cdf functions are currently only supported for "
+            "continuous distributions.")
 
     def _base_discrete_inversion(self, p, func, comp, /, **params):
         # For discrete distributions, icdf(p) is defined as the minimum n

--- a/scipy/stats/_probability_distribution.py
+++ b/scipy/stats/_probability_distribution.py
@@ -1236,7 +1236,7 @@ class _ProbabilityDistribution(ABC):
 
         .. math::
 
-            G(x, y) = 1 - F(x, y) = P(\text{not } x \leq X \leq y)
+            G(x, y) = 1 - F(x, y) = P(X < x \text{ or } X > y)
 
         `ccdf` accepts `x` for :math:`x` and `y` for :math:`y`.
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -524,6 +524,13 @@ def check_cdf2(dist, log, x, y, result_shape, methods):
         assert np.isscalar(ref)
 
     for method in methods:
+        if isinstance(dist, DiscreteDistribution):
+            message = ("Two argument cdf functions are currently only supported for "
+                       "continuous distributions.")
+            with pytest.raises(NotImplementedError, match=message):
+                res = (np.exp(dist.logcdf(x, y, method=method)) if log
+                       else dist.cdf(x, y, method=method))
+            continue
         res = (np.exp(dist.logcdf(x, y, method=method)) if log
                else dist.cdf(x, y, method=method))
         np.testing.assert_allclose(res, ref, atol=1e-14)
@@ -552,6 +559,13 @@ def check_ccdf2(dist, log, x, y, result_shape, methods):
         assert np.isscalar(ref)
 
     for method in methods:
+        message = ("Two argument cdf functions are currently only supported for "
+                   "continuous distributions.")
+        if isinstance(dist, DiscreteDistribution):
+            with pytest.raises(NotImplementedError, match=message):
+                res = (np.exp(dist.logccdf(x, y, method=method)) if log
+                       else dist.ccdf(x, y, method=method))
+            continue
         res = (np.exp(dist.logccdf(x, y, method=method)) if log
                else dist.ccdf(x, y, method=method))
         np.testing.assert_allclose(res, ref, atol=1e-14)

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -333,9 +333,8 @@ class TestDistributions:
         # Safe subtraction is needed in special cases
         x = np.asarray([-1e-20, -1e-21, 1e-20, 1e-21, -1e-20])
         y = np.asarray([-1e-21, -1e-20, 1e-21, 1e-20, 1e-20])
-        p0 = np.asarray(X.pdf(0)*(y-x))
-        p0[(x > y) & ~np.isnan(p0)] = 0.0
-        p0 = p0[()]
+
+        p0 = X.pdf(0)*(y-x)
         p1 = X.cdf(x, y, method='subtraction_safe')
         p2 = X.cdf(x, y, method='subtraction')
         assert_equal(p2, 0)
@@ -517,10 +516,7 @@ def check_cdf2(dist, log, x, y, result_shape, methods):
                 or dist._overrides('_logccdf_formula')):
             methods.add('log/exp')
 
-    ref = np.asarray(dist.cdf(y) - dist.cdf(x) + dist.pmf(x))
-    ref[~np.isnan(ref) & (x > y)] = 0.0
-    ref = ref[()]
-
+    ref = dist.cdf(y) - dist.cdf(x)
     np.testing.assert_equal(ref.shape, result_shape)
 
     if result_shape == tuple():
@@ -548,10 +544,7 @@ def check_ccdf2(dist, log, x, y, result_shape, methods):
     if dist._overrides(f'_{"log" if log else ""}ccdf2_formula'):
         methods.add('formula')
 
-    ref = np.asarray(dist.cdf(x) + dist.ccdf(y) - dist.pmf(x))
-    ref[~np.isnan(ref) & (x > y)] = 1.0
-    ref = ref[()]
-
+    ref = dist.cdf(x) + dist.ccdf(y)
     np.testing.assert_equal(ref.shape, result_shape)
 
     if result_shape == tuple():

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -334,6 +334,7 @@ class TestDistributions:
         x = np.asarray([-1e-20, -1e-21, 1e-20, 1e-21, -1e-20])
         y = np.asarray([-1e-21, -1e-20, 1e-21, 1e-20, 1e-20])
 
+
         p0 = X.pdf(0)*(y-x)
         p1 = X.cdf(x, y, method='subtraction_safe')
         p2 = X.cdf(x, y, method='subtraction')


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR walks back the changes made to two argument cdf here, https://github.com/mdhaber/scipy/pull/121, keeping the sign flip convention for the `x > y` case for continuous distributions, and raising a `NotImplementedError` when calling a cdf function with two args for discrete distributions. I think ultimately, it would be good to consistently use the probability definitions of two arg cdf and two arg ccdf  for both continuous and discrete distributions, but I found it was actually not that easy for me to get this to work correctly in all cases without breaking something or other, or introducing excessive complexity.

I don't want to continue holding up https://github.com/scipy/scipy/pull/22312 due to subtleties of two argument cdf, and my half baked attempts to move to the probability definition on top of code which already added some complexity to allow the sign flip convention. Updating two arg cdf to the probability definition will require some rethinking, so is best left to a separate PR.

#### Additional information
<!--Any additional information you think is important.-->
