### PR TITLE
DOC: stats.sigmaclip: results may not satisfy an intuitive property

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3403,6 +3403,14 @@ def sigmaclip(a, low=4., high=4.):
     upper : float
         Upper threshold value use for clipping.
 
+    Notes
+    -----
+    This function performs the procedure as described, iteratively *removing*
+    observations. Once observations have been removed, they are not considered
+    in subsequent iterations. Consequently, although it is often the case that
+    ``clipped`` is identical to ``a[(a >= lower) & (a <= upper)]``, this property
+    is not guaranteed to be satisfied; ``clipped`` may have fewer elements.
+
     Examples
     --------
     >>> import numpy as np


### PR DESCRIPTION
#### Reference issue
Closes gh-22871

#### What does this implement/fix?
gh-22871 noticed a case in which the result produced by `scipy.stats.sigmaclip` did not satisfy a property that intuitively might hold. The documentation of `sigmaclip` describes the algorithm it follows without making promises about properties of the results, and it turns out that the algorithm does not always produce results with the property. This PR documents that possibility.

#### Additional information
Documentation is the preferred approach to resolve the issue because:
- `sigmaclip` has always behaved this way
- `astropy`'s version of `sigmaclip` behaves the same way
- it is not obvious whether there is an efficient algorithm that would always produce results with the expected property when it is possible